### PR TITLE
 Use EWMA to detect and suppress anomally in asset changes

### DIFF
--- a/contracts/transmuter/Cargo.toml
+++ b/contracts/transmuter/Cargo.toml
@@ -40,6 +40,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
+bigdecimal = "0.3.1"
 cosmwasm-schema = "1.1.2"
 cosmwasm-std = "1.1.2"
 cosmwasm-storage = "1.1.2"

--- a/contracts/transmuter/src/lib.rs
+++ b/contracts/transmuter/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 mod error;
+mod limit;
 mod shares;
 mod sudo;
 mod transmuter_pool;

--- a/contracts/transmuter/src/limit/ewma.rs
+++ b/contracts/transmuter/src/limit/ewma.rs
@@ -1,0 +1,66 @@
+use std::str::FromStr;
+
+use bigdecimal::{BigDecimal, One, ToPrimitive};
+use cosmwasm_std::{Decimal, Deps, DepsMut, StdError, StdResult, Uint128};
+use cw_storage_plus::Item;
+
+pub struct EWMA<'a> {
+    /// The current EWMA value (timestamp, value)
+    pub latest: Item<'a, (u64, Uint128)>,
+
+    /// half life of the EWMA in nanoseconds
+    pub half_life: Item<'a, u64>,
+}
+
+impl EWMA<'_> {
+    pub fn new<'a>(latest_namespace: &'a str, half_life_namespace: &'a str) -> EWMA<'a> {
+        EWMA {
+            latest: Item::new(latest_namespace),
+            half_life: Item::new(half_life_namespace),
+        }
+    }
+
+    pub fn latest(&self, deps: Deps) -> StdResult<Option<(u64, Uint128)>> {
+        self.latest.may_load(deps.storage)
+    }
+
+    pub fn set_half_life(&self, deps: DepsMut, half_life: u64) -> StdResult<()> {
+        self.half_life.save(deps.storage, &half_life)
+    }
+
+    pub fn half_life(&self, deps: Deps) -> StdResult<u64> {
+        self.half_life.load(deps.storage)
+    }
+
+    pub fn update_latest(&self, deps: DepsMut, now: u64, x: Uint128) -> StdResult<()> {
+        let Some((latest_timestamp, latest_ewma)) = self.latest(deps.as_ref())? else {
+            return self.latest.save(deps.storage, &(now, x));
+        };
+
+        let half_life = BigDecimal::from(self.half_life(deps.as_ref())?);
+        let x = BigDecimal::from_str(&x.to_string()).map_err(bigdecimal_to_std_err)?;
+        let latest_ewma =
+            BigDecimal::from_str(&latest_ewma.to_string()).map_err(bigdecimal_to_std_err)?;
+        let detla_t = BigDecimal::from(now - latest_timestamp);
+        let ln_2 = BigDecimal::from_str(
+            "0.6931471805599453094172321214581765680755001343602552541206800094",
+        )
+        .map_err(bigdecimal_to_std_err)?;
+
+        // α = 1 - e^(-ln(2) · Δt / half_life)
+        // α = 1 - 1 / (e^(ln(2) · Δt / half_life))
+        let alpha = BigDecimal::one() - BigDecimal::one() / (ln_2 * detla_t / half_life).exp();
+
+        // ewma(t) = α · x(t) + (1 - α) · ewma(t - 1)
+        let ewma = alpha.clone() * x + (BigDecimal::one() - alpha) * latest_ewma;
+
+        // TODO: this does to_u64() and then back to Uint128, which is not ideal
+        let ewma = ewma.to_u128().unwrap().into();
+
+        self.latest.save(deps.storage, &(now, ewma))
+    }
+}
+
+fn bigdecimal_to_std_err(e: bigdecimal::ParseBigDecimalError) -> StdError {
+    StdError::parse_err("bigdecimal::BigDecimal", e)
+}

--- a/contracts/transmuter/src/limit/mod.rs
+++ b/contracts/transmuter/src/limit/mod.rs
@@ -1,0 +1,1 @@
+mod ewma;


### PR DESCRIPTION
closes #7 

### Background
As transmuter is going to treat LP token as a basket representation of tokens that supposed to have the same price value. To control exposure to risk from each asset in the pool, we need to restrict rate-of-change in the pool assets.

There is [ibc-rate-limit](https://github.com/osmosis-labs/osmosis/blob/acebfcf1ce6880e95c348557d969a7a498e0e6a4/x/ibc-rate-limit/contracts/rate-limiter/src/state.rs) which has similar background and could port it over, but `ibc-rate-limit` implementation is based on fixed-length window which once the period ends, it resets. Which, the potential improvements has been stated in the README that is:

> Currently these rate limits automatically "expire" at the end of the quota duration. TODO: Think of better designs here. E.g. can we have a constant number of subsequent quotas start filled? Or perhaps harmonically decreasing amounts of next few quotas pre-filled? Halted until DAO override seems not-great.

This proposal suggest a different approach while still keeping minimum state and window recalculations.

### Implementation
The idea is to use Expoential Weighted Moving Average (EWMA) to detect and suppress anomally in asset changes.

### Baseline
Uses EWMA to establish a baseline for drawing boundary for changes in asset. EWMA has a fast online algorithm, that is:

$$ EWMA(t) = \alpha * x(t) + (1 - \alpha) * EWMA(t-1) $$

where $\alpha$ is a smoothing factor, $x(t)$ is the value at time $t$ and $EWMA(t-1)$ is the EWMA at time $t-1$.

This has recurrence relation so we only need to store the previous EWMA value and the smoothing factor.

Since changes may come at irregular intervals, we need to calculate the $\alpha$ for each change. The smoothing factor $\alpha$ is calculated as:

$$ \alpha = 1 - e^{\frac{ln(0.5)}{H}\Delta{t}} $$

where $H$ is the half-life of the EWMA and $\Delta{t}$ is the time between the previous EWMA and the current value.

The parameter $H$ is determining how fast the EWMA reacts to changes. The smaller the $H$, the faster the EWMA reacts to changes since it means that time for past values to be half-forgotten is shorter.

### Boundary
As we establish the baseline, we can use the EWMA to draw the boundary for changes in asset. The parameter is maximum percentage change in asset value, donoted as $M$. The boundary is calculated as:

$$ B = EWMA(t) \cdot (1 + M) $$

If the incoming change causes the asset to hit the boundary, the change will be rejected.

With $H$ and $M$ as parameters, we can predict the maximum increase in asset value in a given time period which can be viewed as rolling window with a few more knobs but no window recalculations and few storage reads & writes.

(WIP)
