### PR TITLE
static limiter

### DIFF
--- a/contracts/transmuter/src/contract.rs
+++ b/contracts/transmuter/src/contract.rs
@@ -2,7 +2,7 @@ use crate::{
     admin::Admin,
     ensure_admin_authority,
     error::ContractError,
-    limiter::{Limiter, LimiterParams, Limiters, WindowConfig},
+    limiter::{Limiter, LimiterParams, Limiters},
     shares::Shares,
     transmuter_pool::TransmuterPool,
 };
@@ -744,7 +744,7 @@ pub struct GetAdminCandidateResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::limiter::ChangeLimiter;
+    use crate::limiter::{ChangeLimiter, WindowConfig};
     use crate::sudo::SudoMsg;
     use crate::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};

--- a/contracts/transmuter/src/error.rs
+++ b/contracts/transmuter/src/error.rs
@@ -95,6 +95,9 @@ pub enum ContractError {
         value: Decimal,
     },
 
+    #[error("Modifying wrong limiter type: expected: {expected}, actual: {actual}")]
+    WrongLimiterType { expected: String, actual: String },
+
     #[error("{0}")]
     OverflowError(#[from] OverflowError),
 

--- a/contracts/transmuter/src/error.rs
+++ b/contracts/transmuter/src/error.rs
@@ -87,9 +87,9 @@ pub enum ContractError {
     LimiterAlreadyExists { denom: String, label: String },
 
     #[error(
-        "Change upper limit exceeded for `{denom}`, upper limit is {upper_limit}, but the resulted ratio is {value}"
+        "Upper limit exceeded for `{denom}`, upper limit is {upper_limit}, but the resulted weight is {value}"
     )]
-    ChangeUpperLimitExceeded {
+    UpperLimitExceeded {
         denom: String,
         upper_limit: Decimal,
         value: Decimal,

--- a/contracts/transmuter/src/limiter/mod.rs
+++ b/contracts/transmuter/src/limiter/mod.rs
@@ -2,4 +2,4 @@ mod division;
 mod helpers;
 mod limiters;
 
-pub use limiters::{ChangeLimiter, Limiter, LimiterParams, Limiters, WindowConfig};
+pub use limiters::{ChangeLimiter, Limiter, LimiterParams, Limiters, StaticLimiter, WindowConfig};

--- a/contracts/transmuter/src/limiter/mod.rs
+++ b/contracts/transmuter/src/limiter/mod.rs
@@ -2,4 +2,4 @@ mod division;
 mod helpers;
 mod limiters;
 
-pub use limiters::{ChangeLimiter, Limiter, Limiters, WindowConfig};
+pub use limiters::{ChangeLimiter, Limiter, LimiterParams, Limiters, WindowConfig};

--- a/contracts/transmuter/src/limiter/mod.rs
+++ b/contracts/transmuter/src/limiter/mod.rs
@@ -1,4 +1,4 @@
-mod compressed_sma_division;
+mod division;
 mod helpers;
 mod limiters;
 


### PR DESCRIPTION
- expose setting custom subdenom on instantiate
- rename comprehensive flows to scenarios
- implement admin
- expose set denom metadata
- add tests for admin fns
- fixing ci
- downgrade rust on gh action to 1.69
- allow swapping shares with SwapExactAmountIn
-  allow swapping shares with SwapExactAmountOut
- update osmosis deps version
- move all storage key def to contract.rs
- bump version to 1.0.0
- rename attr
- add test for create pool
- remove expect from transmute
- add test for estimate
- remove unused import
- update optimizer version
- update dependencies
- update comments
- add admin logic
- test set active
- expose admin transfer functionality
- make codecov runs
- update readme
- update types
- add more test for swap exact amount out
- ignore test that requires v17 to pass
- Update README.md
- remove ignored test
- create compressed division
- create moving average module
- initialize another attempt on compressed division
- add test for the division edge
- implement multitple divs avg
- error on updated at greater and started at
- refactor calc logic
- average with overlapping windows
- refactor
- impl out of window check
- clean up old divisions
- rename average to compressed moving average
- refactor and update set config limitation
- remove outdated divs
- implement check and update and test part of it
- add next started at
- implement skipped div average
- add test for clean up
- write test for next started at
- update set config logic
- fix failing test
- clean up and document
- rename cumsum to integral
- add docs and clean up code
- make monotonicity error explicit
- update doc & publicity for CompressedSMALimiter
- refactor integral range logic
- setup for contract integration
- move state definition to it's own mod
- Revert "move state definition to it's own mod"
- move all limiters stored in compressed sma limiter manager
- remove unused storage
- move ensure upper limit to CompressedSMALimiter
- refractor
- remove unused comments and code
- test and add checks to registration process
- impl ratio function for pool
- add list limiters and list limiters by denom
- extract ensure upper limit and update function
- plan out remaining works
- add tests for limiter interface
- implement all ratios
- test and change interface for change and update limiters
- hook limiters into swaps/join/exit
- fix rebase problems
- rename share to allyed assets
- removed unused code
- remove needs for VecDeque
- gitinnore tarpaulin-report.html
- remove dbg
- rename human readable windwo to label
- rename ratio to weight
- rename to change limiter
- make limiter generic with sum type
- rename compressed sma division to  division
- generalize limiter reg
- update registration and set boundary to check for limiter type
- check upper limit from static limiter
- expose and test set static limiter upper limit
