### PR TITLE
Change add_new_assets schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Admin can `add_new_assets`
 ```json
 {
   "add_new_assets": {
-    "assets": [
+    "asset_configs": [
       { "denom": "ibc/a..", "normalization_factor": "1000000" },
       { "denom": "ibc/b..", "normalization_factor": "1" }
     ]


### PR DESCRIPTION
Assets was incorrect for this message, asset_configs was needed to modify 
https://celatone.osmosis.zone/osmo-test-5/txs/E986A280A7272A6CD42474195F6705171A14E6C04395697EFE6DBC8AFE5C04FA

Tested against 3.0 on testnet ahead of modifying allUSDT contract which is based on 3.0