### PR TITLE
[FIX] Asset group decimal error

### DIFF
--- a/contracts/transmuter/src/contract.rs
+++ b/contracts/transmuter/src/contract.rs
@@ -233,6 +233,7 @@ impl Transmuter {
             .map(|(denom, weight)| (Scope::denom(&denom).key(), weight));
         let asset_group_weights_iter = pool
             .asset_group_weights()?
+            .unwrap_or_default()
             .into_iter()
             .map(|(label, weight)| (Scope::asset_group(&label).key(), weight));
 

--- a/contracts/transmuter/src/error.rs
+++ b/contracts/transmuter/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     CheckedFromRatioError, CheckedMultiplyRatioError, Coin, ConversionOverflowError, Decimal,
-    DivideByZeroError, OverflowError, StdError, Timestamp, Uint128, Uint64,
+    DecimalRangeExceeded, DivideByZeroError, OverflowError, StdError, Timestamp, Uint128, Uint64,
 };
 use thiserror::Error;
 
@@ -209,6 +209,8 @@ pub enum ContractError {
     #[error("{0}")]
     ConversionOverflowError(#[from] ConversionOverflowError),
 
+    #[error("{0}")]
+    DecimalRangeExceeded(#[from] DecimalRangeExceeded),
     #[error("{0}")]
     MathError(#[from] MathError),
 

--- a/contracts/transmuter/src/limiter.rs
+++ b/contracts/transmuter/src/limiter.rs
@@ -627,7 +627,7 @@ macro_rules! assert_reset_change_limiters_by_scope {
             .into_iter()
             .collect::<std::collections::HashMap<_, _>>();
 
-        let asset_group_weights = pool.asset_group_weights().unwrap();
+        let asset_group_weights = pool.asset_group_weights().unwrap().unwrap_or_default();
 
         let limiters = $transmuter
             .limiters

--- a/contracts/transmuter/src/transmuter_pool/weight.rs
+++ b/contracts/transmuter/src/transmuter_pool/weight.rs
@@ -51,7 +51,7 @@ impl TransmuterPool {
         Ok(Some(ratios))
     }
 
-    fn normalized_asset_values(
+    pub(crate) fn normalized_asset_values(
         &self,
         std_norm_factor: Uint128,
     ) -> Result<Vec<(String, Uint128)>, ContractError> {


### PR DESCRIPTION
When asset weights in the same group having decimal places over 18, there could be the case where the resulted weight is decreased when it shouldn't. Considering a group where 

previous weights: A = 1, B = 0
updated weights: A = 1/3, B = 2/3

But due to precision loss, A = 0.333333333333333333, B = 0.666666666666666666 which resulted in 0.999999999999999999 which is viewed as decreasing weight and bypass the limiter (decreasing weight shoud not be prohibited even if it's not yet below the bound as it improves the pool balances but this case does not).

The fix is delaying division and sum the normalized value first as opposed to just sum the denom weights.
