### PR TITLE
Collect fee & incentivize non-alloyed swaps

### DIFF
--- a/contracts/transmuter/src/contract.rs
+++ b/contracts/transmuter/src/contract.rs
@@ -1,4 +1,6 @@
-use crate::{corruptable::Corruptable, rebalancer::Rebalancer, scope::Scope};
+use crate::{
+    corruptable::Corruptable, incentive_pool::IncentivePool, rebalancer::Rebalancer, scope::Scope,
+};
 use std::{collections::BTreeMap, iter};
 
 use crate::{
@@ -41,6 +43,7 @@ pub struct Transmuter {
     pub(crate) alloyed_asset: AlloyedAsset,
     pub(crate) role: Role,
     pub(crate) rebalancer: Rebalancer,
+    pub(crate) incentive_pool: IncentivePool,
 }
 
 pub mod key {
@@ -50,7 +53,11 @@ pub mod key {
     pub const ALLOYED_ASSET_NORMALIZATION_FACTOR: &str = "alloyed_asset_normalization_factor";
     pub const ADMIN: &str = "admin";
     pub const MODERATOR: &str = "moderator";
-    pub const REBALANCER: &str = "rebalancer"; // TODO: migrate data from limiters
+    pub const REBALANCER: &str = "rebalancer";
+    pub const INCENTIVE_POOL_BALANCES: &str = "incentive_pool_balances";
+    pub const INCENTIVE_POOL_OUTSTANDING_CREDITS: &str = "incentive_pool_outstanding_credits";
+    pub const INCENTIVE_POOL_TOTAL_OUTSTANDING_CREDITS: &str =
+        "incentive_pool_total_outstanding_credits";
 }
 
 #[contract]
@@ -67,6 +74,11 @@ impl Transmuter {
             ),
             role: Role::new(key::ADMIN, key::MODERATOR),
             rebalancer: Rebalancer::new(key::REBALANCER),
+            incentive_pool: IncentivePool::new(
+                key::INCENTIVE_POOL_BALANCES,
+                key::INCENTIVE_POOL_OUTSTANDING_CREDITS,
+                key::INCENTIVE_POOL_TOTAL_OUTSTANDING_CREDITS,
+            ),
         }
     }
 

--- a/contracts/transmuter/src/contract.rs
+++ b/contracts/transmuter/src/contract.rs
@@ -823,6 +823,16 @@ impl Transmuter {
         })
     }
 
+    #[sv::msg(query)]
+    pub fn get_incentive_pool_balances(
+        &self,
+        ctx::QueryCtx { deps, .. }: ctx::QueryCtx,
+    ) -> Result<GetIncentivePoolBalancesResponse, ContractError> {
+        let balances = self.incentive_pool.get_all_pool_balances(deps.storage)?;
+
+        Ok(GetIncentivePoolBalancesResponse { balances })
+    }
+
     // --- admin ---
 
     #[sv::msg(exec)]
@@ -985,6 +995,11 @@ pub struct CalcInAmtGivenOutResponse {
 #[cw_serde]
 pub struct GetCorrruptedScopesResponse {
     pub corrupted_scopes: Vec<Scope>,
+}
+
+#[cw_serde]
+pub struct GetIncentivePoolBalancesResponse {
+    pub balances: Vec<Coin>,
 }
 
 #[cw_serde]

--- a/contracts/transmuter/src/swap.rs
+++ b/contracts/transmuter/src/swap.rs
@@ -2235,8 +2235,8 @@ mod tests {
         let res = transmuter.swap_non_alloyed_exact_amount_out(
             token_in_denom,
             token_in_amount,
-            token_out,
-            sender,
+            token_out.clone(),
+            sender.clone(),
             deps.as_mut(),
         );
 
@@ -2272,6 +2272,93 @@ mod tests {
             .get_all_incentive_credits(&deps.storage, None, None)
             .unwrap();
         assert_eq!(credits, vec![]);
+
+        // swap back with the same amount
+        let res = transmuter
+            .swap_non_alloyed_exact_amount_in(
+                token_out,
+                "denom1",
+                amount_in_before_fee,
+                sender.clone(),
+                deps.as_mut(),
+            )
+            .unwrap();
+        let data: SwapExactAmountInResponseData = from_json(&res.data.unwrap()).unwrap();
+        assert_eq!(
+            data,
+            SwapExactAmountInResponseData {
+                token_out_amount: amount_in_before_fee,
+            }
+        );
+
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+
+        assert_eq!(
+            pool.pool_assets,
+            vec![
+                Asset::new(Uint128::from(100_000_000_000u128), "denom1", 1u128).unwrap(),
+                Asset::new(Uint128::from(500_000_000_000u128), "denom2", 10u128).unwrap(),
+                Asset::new(Uint128::from(5_000_000_000_000u128), "denom3", 100u128).unwrap(),
+            ]
+        );
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+        assert_eq!(
+            credits,
+            vec![(sender.clone(), fee * Uint128::from(100u128))]
+        );
+
+        let pool_denom_factors = pool
+            .pool_assets
+            .iter()
+            .map(|asset| (asset.denom().to_string(), asset.normalization_factor()))
+            .collect::<BTreeMap<_, _>>();
+
+        let err = transmuter
+            .incentive_pool
+            .redeem_incentive(
+                &mut deps.storage,
+                &sender,
+                vec![coin(fee.u128() + 1, "denom1")],
+                &pool_denom_factors,
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            ContractError::InsufficientIncentiveCredit {
+                user: sender.clone(),
+                available: fee * Uint128::from(100u128),
+                requested: (fee + Uint128::from(1u128)) * Uint128::from(100u128),
+            }
+        );
+
+        transmuter
+            .incentive_pool
+            .redeem_incentive(
+                &mut deps.storage,
+                &sender,
+                vec![coin(fee.u128(), "denom1")],
+                &pool_denom_factors,
+            )
+            .unwrap();
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+
+        assert_eq!(credits, vec![]);
+
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+
+        assert_eq!(incentive_pool_balances, vec![]);
     }
 
     #[test]
@@ -2304,10 +2391,10 @@ mod tests {
         );
 
         let res = transmuter.swap_non_alloyed_exact_amount_in(
-            token_in,
+            token_in.clone(),
             "denom2",
             token_out_amount,
-            sender,
+            sender.clone(),
             deps.as_mut(),
         );
 
@@ -2343,5 +2430,89 @@ mod tests {
             .get_all_incentive_credits(&deps.storage, None, None)
             .unwrap();
         assert_eq!(credits, vec![]);
+
+        // swap back with the same amount
+        let res = transmuter.swap_non_alloyed_exact_amount_out(
+            "denom2",
+            amount_out_before_fee,
+            token_in,
+            sender.clone(),
+            deps.as_mut(),
+        );
+
+        let data: SwapExactAmountOutResponseData = from_json(&res.unwrap().data.unwrap()).unwrap();
+        assert_eq!(
+            data,
+            SwapExactAmountOutResponseData {
+                token_in_amount: amount_out_before_fee,
+            }
+        );
+
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+
+        assert_eq!(
+            pool.pool_assets,
+            vec![
+                Asset::new(Uint128::from(100_000_000_000u128), "denom1", 1u128).unwrap(),
+                Asset::new(Uint128::from(500_000_000_000u128), "denom2", 10u128).unwrap(),
+                Asset::new(Uint128::from(5_000_000_000_000u128), "denom3", 100u128).unwrap(),
+            ]
+        );
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+
+        assert_eq!(credits, vec![(sender.clone(), fee * Uint128::from(10u128))]);
+
+        let pool_denom_factors = pool
+            .pool_assets
+            .iter()
+            .map(|asset| (asset.denom().to_string(), asset.normalization_factor()))
+            .collect::<BTreeMap<_, _>>();
+
+        let err = transmuter
+            .incentive_pool
+            .redeem_incentive(
+                &mut deps.storage,
+                &sender,
+                vec![coin(fee.u128() + 1, "denom2")],
+                &pool_denom_factors,
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            ContractError::InsufficientIncentiveCredit {
+                user: sender.clone(),
+                available: fee * Uint128::from(10u128),
+                requested: (fee + Uint128::from(1u128)) * Uint128::from(10u128),
+            }
+        );
+
+        transmuter
+            .incentive_pool
+            .redeem_incentive(
+                &mut deps.storage,
+                &sender,
+                vec![coin(fee.u128(), "denom2")],
+                &pool_denom_factors,
+            )
+            .unwrap();
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+
+        assert_eq!(credits, vec![]);
+
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+
+        assert_eq!(incentive_pool_balances, vec![]);
     }
 }

--- a/contracts/transmuter/src/test/cases/units/swap/mod.rs
+++ b/contracts/transmuter/src/test/cases/units/swap/mod.rs
@@ -532,5 +532,6 @@ fn pool_with_single_lp(
 mod client_error;
 mod non_empty_pool;
 mod swap_share_denom;
+mod swap_with_fee_deduction;
 
 mod swap_with_asset_group_limiters;

--- a/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
+++ b/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
@@ -12,7 +12,7 @@ use crate::test::{modules::cosmwasm_pool::CosmwasmPool, test_env::TestEnv};
 use crate::{
     asset::AssetConfig,
     contract::sv::{ExecMsg, QueryMsg},
-    contract::GetTotalPoolLiquidityResponse,
+    contract::{GetIncentivePoolBalancesResponse, GetTotalPoolLiquidityResponse},
     scope::Scope,
     test::test_env::TestEnvBuilder,
 };
@@ -243,6 +243,21 @@ fn verify_contract_balances(
         .contract
         .query(&QueryMsg::GetTotalPoolLiquidity {})
         .unwrap();
+
+    // Query the incentive pool balances from the contract
+    let incentive_pool_balances: GetIncentivePoolBalancesResponse = t
+        .contract
+        .query(&QueryMsg::GetIncentivePoolBalances {})
+        .unwrap();
+
+    // Verify the incentive pool balances
+    for balance in incentive_pool_balances.balances {
+        if balance.denom == fee_denom {
+            assert_eq!(balance.amount, expected_fee_amount);
+        } else {
+            assert_eq!(balance.amount, Uint128::zero());
+        }
+    }
 
     // For each denom in the pool, verify contract balance
     for pool_coin in &pool_liquidity.total_pool_liquidity {

--- a/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
+++ b/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
@@ -1,0 +1,275 @@
+use cosmwasm_std::{coin, Decimal, Uint128};
+use osmosis_std::types::{
+    cosmos::bank::v1beta1::QueryBalanceRequest,
+    osmosis::poolmanager::v1beta1::{
+        MsgSwapExactAmountIn, MsgSwapExactAmountOut, SwapAmountInRoute, SwapAmountOutRoute,
+    },
+};
+use osmosis_test_tube::{Account, Bank, Module, OsmosisTestApp};
+use transmuter_math::rebalancing::config::RebalancingConfig;
+
+use crate::test::{modules::cosmwasm_pool::CosmwasmPool, test_env::TestEnv};
+use crate::{
+    asset::AssetConfig,
+    contract::sv::{ExecMsg, QueryMsg},
+    contract::GetTotalPoolLiquidityResponse,
+    scope::Scope,
+    test::test_env::TestEnvBuilder,
+};
+
+const DENOM1_INITIAL: u128 = 100_000_000_000;
+const DENOM2_INITIAL: u128 = 500_000_000_000;
+const DENOM3_INITIAL: u128 = 5_000_000_000_000;
+
+#[test]
+fn test_swap_exact_amount_out_with_fee_deduction() {
+    let app = OsmosisTestApp::new();
+    let t = setup_test_env(&app);
+    let cp = CosmwasmPool::new(&app);
+
+    // Test the swap that should require fee
+    // This swap makes denom1 weight go from 50% to 60%, triggering fee
+    let token_out = coin(200_000_000_000u128, "denom2");
+    let amount_in_before_fee = Uint128::from(20_000_000_000u128);
+    let expected_fee = Uint128::from(1_000_000_000u128) + Uint128::from(3_000_000_000u128); // group1 + denom1 fees
+    let token_in_amount = amount_in_before_fee + expected_fee;
+
+    // Test with insufficient max amount (should fail)
+    let insufficient_max = token_in_amount - Uint128::from(1u128);
+    let err = cp
+        .swap_exact_amount_out(
+            MsgSwapExactAmountOut {
+                sender: t.accounts["swapper"].address(),
+                routes: vec![SwapAmountOutRoute {
+                    pool_id: t.contract.pool_id,
+                    token_in_denom: "denom1".to_string(),
+                }],
+                token_out: Some(token_out.clone().into()),
+                token_in_max_amount: insufficient_max.to_string(),
+            },
+            &t.accounts["swapper"],
+        )
+        .unwrap_err();
+
+    // Should fail due to excessive token in required
+    assert!(err.to_string().contains("Excessive token in required"));
+
+    // Test with sufficient max amount (should succeed)
+    cp.swap_exact_amount_out(
+        MsgSwapExactAmountOut {
+            sender: t.accounts["swapper"].address(),
+            routes: vec![SwapAmountOutRoute {
+                pool_id: t.contract.pool_id,
+                token_in_denom: "denom1".to_string(),
+            }],
+            token_out: Some(token_out.into()),
+            token_in_max_amount: token_in_amount.to_string(),
+        },
+        &t.accounts["swapper"],
+    )
+    .unwrap();
+
+    // Verify contract balances include pool liquidity + collected fees
+    verify_contract_balances(&t, expected_fee, "denom1");
+}
+
+#[test]
+fn test_swap_exact_amount_in_with_fee_deduction() {
+    let app = OsmosisTestApp::new();
+    let cp = CosmwasmPool::new(&app);
+
+    let t = setup_test_env(&app);
+
+    // Test the swap that should require fee deduction from output
+    let token_in = coin(20_000_000_000u128, "denom1");
+    let amount_out_before_fee = Uint128::from(200_000_000_000u128);
+    let expected_fee = Uint128::from(10_000_000_000u128) + Uint128::from(30_000_000_000u128); // group1 + denom1 fees
+    let token_out_amount = amount_out_before_fee - expected_fee;
+
+    // Test with min amount too high (should fail)
+    let excessive_min = token_out_amount + Uint128::from(1u128);
+    let err = cp
+        .swap_exact_amount_in(
+            MsgSwapExactAmountIn {
+                sender: t.accounts["swapper"].address(),
+                routes: vec![SwapAmountInRoute {
+                    pool_id: t.contract.pool_id,
+                    token_out_denom: "denom2".to_string(),
+                }],
+                token_in: Some(token_in.clone().into()),
+                token_out_min_amount: excessive_min.to_string(),
+            },
+            &t.accounts["swapper"],
+        )
+        .unwrap_err();
+
+    // Should fail due to insufficient token out
+    assert!(err.to_string().contains("Insufficient token out"));
+
+    // Test with appropriate min amount (should succeed)
+    cp.swap_exact_amount_in(
+        MsgSwapExactAmountIn {
+            sender: t.accounts["swapper"].address(),
+            routes: vec![SwapAmountInRoute {
+                pool_id: t.contract.pool_id,
+                token_out_denom: "denom2".to_string(),
+            }],
+            token_in: Some(token_in.into()),
+            token_out_min_amount: token_out_amount.to_string(),
+        },
+        &t.accounts["swapper"],
+    )
+    .unwrap();
+
+    // Verify contract balances include pool liquidity + collected fees
+    verify_contract_balances(&t, expected_fee, "denom2");
+}
+
+fn setup_test_env<'a>(app: &'a OsmosisTestApp) -> TestEnv<'a> {
+    let admin = app.init_account(&[coin(100_000u128, "uosmo")]).unwrap();
+
+    let t = TestEnvBuilder::new()
+        .with_account("admin", vec![])
+        .with_account("swapper", vec![coin(1_000_000_000_000, "denom1")])
+        .with_account(
+            "provider",
+            vec![
+                coin(DENOM1_INITIAL, "denom1"),
+                coin(DENOM2_INITIAL, "denom2"),
+                coin(DENOM3_INITIAL, "denom3"),
+            ],
+        )
+        .with_instantiate_msg(crate::contract::sv::InstantiateMsg {
+            pool_asset_configs: vec![
+                AssetConfig {
+                    denom: "denom1".to_string(),
+                    normalization_factor: Uint128::one(),
+                },
+                AssetConfig {
+                    denom: "denom2".to_string(),
+                    normalization_factor: Uint128::new(10),
+                },
+                AssetConfig {
+                    denom: "denom3".to_string(),
+                    normalization_factor: Uint128::new(100),
+                },
+            ],
+            alloyed_asset_subdenom: "usd".to_string(),
+            alloyed_asset_normalization_factor: Uint128::new(100),
+            admin: Some(admin.address()),
+            moderator: "osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks".to_string(),
+        })
+        .build(&app);
+
+    // Add initial liquidity to the pool
+    t.contract
+        .execute(
+            &ExecMsg::JoinPool {},
+            &[
+                coin(DENOM1_INITIAL, "denom1"),
+                coin(DENOM2_INITIAL, "denom2"),
+                coin(DENOM3_INITIAL, "denom3"),
+            ],
+            &t.accounts["provider"],
+        )
+        .unwrap();
+
+    // Create asset group for denom2 and denom3
+    t.contract
+        .execute(
+            &ExecMsg::CreateAssetGroup {
+                label: "group1".to_string(),
+                denoms: vec!["denom2".to_string(), "denom3".to_string()],
+            },
+            &[],
+            &t.accounts["admin"],
+        )
+        .unwrap();
+
+    // Add rebalancing config for denom1 (same as unit test)
+    t.contract
+        .execute(
+            &ExecMsg::AddRebalancingConfig {
+                scope: Scope::denom("denom1"),
+                rebalancing_config: RebalancingConfig::new(
+                    Decimal::percent(50),
+                    Decimal::percent(45),
+                    Decimal::percent(55),
+                    Decimal::percent(30),
+                    Decimal::percent(65),
+                    Decimal::percent(10),
+                    Decimal::percent(20),
+                )
+                .unwrap(),
+            },
+            &[],
+            &t.accounts["admin"],
+        )
+        .unwrap();
+
+    t.contract
+        .execute(
+            &ExecMsg::AddRebalancingConfig {
+                scope: Scope::asset_group("group1"),
+                rebalancing_config: RebalancingConfig::new(
+                    Decimal::percent(55),
+                    Decimal::percent(45),
+                    Decimal::percent(60),
+                    Decimal::percent(30),
+                    Decimal::percent(65),
+                    Decimal::percent(10),
+                    Decimal::percent(20),
+                )
+                .unwrap(),
+            },
+            &[],
+            &t.accounts["admin"],
+        )
+        .unwrap();
+
+    t
+}
+
+/// Helper function to verify that contract balances equal pool liquidity plus collected fees
+fn verify_contract_balances(
+    t: &crate::test::test_env::TestEnv,
+    expected_fee_amount: Uint128,
+    fee_denom: &str,
+) {
+    let bank = Bank::new(t.app);
+
+    // Query the pool liquidity from the contract
+    let pool_liquidity: GetTotalPoolLiquidityResponse = t
+        .contract
+        .query(&QueryMsg::GetTotalPoolLiquidity {})
+        .unwrap();
+
+    // For each denom in the pool, verify contract balance
+    for pool_coin in &pool_liquidity.total_pool_liquidity {
+        let contract_balance = bank
+            .query_balance(&QueryBalanceRequest {
+                address: t.contract.contract_addr.to_string(),
+                denom: pool_coin.denom.clone(),
+            })
+            .unwrap()
+            .balance
+            .unwrap();
+
+        let expected_balance = if pool_coin.denom == fee_denom {
+            // For the fee denom, expect pool amount + collected fees
+            pool_coin.amount + expected_fee_amount
+        } else {
+            // For other denoms, expect just the pool amount
+            pool_coin.amount
+        };
+
+        assert_eq!(
+            contract_balance.amount.parse::<u128>().unwrap(),
+            expected_balance.u128(),
+            "Contract balance mismatch for {}: expected {}, got {}",
+            pool_coin.denom,
+            expected_balance,
+            contract_balance.amount
+        );
+    }
+}

--- a/contracts/transmuter/src/transmuter_pool/weight.rs
+++ b/contracts/transmuter/src/transmuter_pool/weight.rs
@@ -21,11 +21,7 @@ impl TransmuterPool {
     /// If total pool asset amount is zero, returns None to signify that
     /// it makes no sense to calculate ratios, but not an error.
     pub fn asset_weights(&self) -> Result<Option<BTreeMap<String, Decimal>>, ContractError> {
-        let std_norm_factor = lcm_from_iter(
-            self.pool_assets
-                .iter()
-                .map(|pool_asset| pool_asset.normalization_factor()),
-        )?;
+        let std_norm_factor = self.std_norm_factor()?;
 
         let normalized_asset_values = self.normalized_asset_values(std_norm_factor)?;
 
@@ -49,6 +45,14 @@ impl TransmuterPool {
             .collect::<Result<_, ContractError>>()?;
 
         Ok(Some(ratios))
+    }
+
+    pub fn std_norm_factor(&self) -> Result<Uint128, ContractError> {
+        Ok(lcm_from_iter(
+            self.pool_assets
+                .iter()
+                .map(|pool_asset| pool_asset.normalization_factor()),
+        )?)
     }
 
     pub(crate) fn normalized_asset_values(

--- a/packages/transmuter_math/src/rebalancing/zone.rs
+++ b/packages/transmuter_math/src/rebalancing/zone.rs
@@ -19,8 +19,9 @@ pub struct Zone {
 
 impl Zone {
     pub fn new(start: Bound, end: Bound, adjustment_rate: Decimal) -> Self {
+        let (start_bound, end_bound) = force_inclusive_if_has_same_value(start, end);
         Self {
-            range: Range::new(inclusive_if_zero(start), inclusive_if_zero(end)).unwrap(),
+            range: Range::new(start_bound, end_bound).unwrap(),
             adjustment_rate,
         }
     }
@@ -56,11 +57,15 @@ impl Zone {
     }
 }
 
-fn inclusive_if_zero(bound: Bound) -> Bound {
-    if bound.value() == Decimal::zero() {
-        Bound::Inclusive(Decimal::zero())
+fn force_inclusive_if_has_same_value(start: Bound, end: Bound) -> (Bound, Bound) {
+    // If both bounds have the same value, make them both inclusive to create a valid single-point range
+    if start.value() == end.value() {
+        (
+            Bound::Inclusive(start.value()),
+            Bound::Inclusive(end.value()),
+        )
     } else {
-        bound
+        (start, end)
     }
 }
 


### PR DESCRIPTION
This PR implements fee collection and incentive mechanisms for non-alloyed token swaps in the Transmuter contract, extending the existing rebalancing system to handle fee deduction and incentive credits during swap operations.

## Fee Collection & Incentive System
- Implements dynamic fee collection based on rebalancing adjustment values
- Adds incentive credit system for users who help rebalance the pool
- Integrates with the existing rebalancer module to calculate adjustment values

## Enhanced Swap Operations
- Updates `swap_non_alloyed_exact_amount_in` and `swap_non_alloyed_exact_amount_out` functions
- Adds `rebalancer_pass` mechanism that calculates adjustment values and applies fees/incentives

Introduces `Adjustment` enum to handle three scenarios:
- DeductFee: Collect fees from users causing imbalance
- CreditIncentive: Reward users helping to rebalance
- None: No adjustment needed

## Improved Code Structure
- Refactors rebalancer pass types for flexibity in handling different scnarios
- Adds comprehensive error handling and validation
- Implements proper fee calculation with normalization factors