### PR TITLE
Collect fee & incentivize alloyed swaps 

### DIFF
--- a/contracts/transmuter/src/contract.rs
+++ b/contracts/transmuter/src/contract.rs
@@ -1,4 +1,6 @@
-use crate::{corruptable::Corruptable, rebalancer::Rebalancer, scope::Scope};
+use crate::{
+    corruptable::Corruptable, incentive_pool::IncentivePool, rebalancer::Rebalancer, scope::Scope,
+};
 use std::{collections::BTreeMap, iter};
 
 use crate::{
@@ -41,6 +43,7 @@ pub struct Transmuter {
     pub(crate) alloyed_asset: AlloyedAsset,
     pub(crate) role: Role,
     pub(crate) rebalancer: Rebalancer,
+    pub(crate) incentive_pool: IncentivePool,
 }
 
 pub mod key {
@@ -50,7 +53,11 @@ pub mod key {
     pub const ALLOYED_ASSET_NORMALIZATION_FACTOR: &str = "alloyed_asset_normalization_factor";
     pub const ADMIN: &str = "admin";
     pub const MODERATOR: &str = "moderator";
-    pub const REBALANCER: &str = "rebalancer"; // TODO: migrate data from limiters
+    pub const REBALANCER: &str = "rebalancer";
+    pub const INCENTIVE_POOL_BALANCES: &str = "incentive_pool_balances";
+    pub const INCENTIVE_POOL_OUTSTANDING_CREDITS: &str = "incentive_pool_outstanding_credits";
+    pub const INCENTIVE_POOL_TOTAL_OUTSTANDING_CREDITS: &str =
+        "incentive_pool_total_outstanding_credits";
 }
 
 #[contract]
@@ -67,6 +74,11 @@ impl Transmuter {
             ),
             role: Role::new(key::ADMIN, key::MODERATOR),
             rebalancer: Rebalancer::new(key::REBALANCER),
+            incentive_pool: IncentivePool::new(
+                key::INCENTIVE_POOL_BALANCES,
+                key::INCENTIVE_POOL_OUTSTANDING_CREDITS,
+                key::INCENTIVE_POOL_TOTAL_OUTSTANDING_CREDITS,
+            ),
         }
     }
 

--- a/contracts/transmuter/src/contract.rs
+++ b/contracts/transmuter/src/contract.rs
@@ -823,6 +823,16 @@ impl Transmuter {
         })
     }
 
+    #[sv::msg(query)]
+    pub fn get_incentive_pool_balances(
+        &self,
+        ctx::QueryCtx { deps, .. }: ctx::QueryCtx,
+    ) -> Result<GetIncentivePoolBalancesResponse, ContractError> {
+        let balances = self.incentive_pool.get_all_pool_balances(deps.storage)?;
+
+        Ok(GetIncentivePoolBalancesResponse { balances })
+    }
+
     // --- admin ---
 
     #[sv::msg(exec)]
@@ -985,6 +995,11 @@ pub struct CalcInAmtGivenOutResponse {
 #[cw_serde]
 pub struct GetCorrruptedScopesResponse {
     pub corrupted_scopes: Vec<Scope>,
+}
+
+#[cw_serde]
+pub struct GetIncentivePoolBalancesResponse {
+    pub balances: Vec<Coin>,
 }
 
 #[cw_serde]

--- a/contracts/transmuter/src/error.rs
+++ b/contracts/transmuter/src/error.rs
@@ -1,6 +1,7 @@
 use cosmwasm_std::{
     Addr, CheckedFromRatioError, CheckedMultiplyRatioError, Coin, ConversionOverflowError, Decimal,
-    DecimalRangeExceeded, DivideByZeroError, OverflowError, StdError, Uint128, Uint64,
+    DecimalRangeExceeded, DivideByZeroError, OverflowError, SignedDecimal256RangeExceeded,
+    StdError, Uint128, Uint64,
 };
 use thiserror::Error;
 
@@ -201,6 +202,9 @@ pub enum ContractError {
     DecimalRangeExceeded(#[from] DecimalRangeExceeded),
     #[error("{0}")]
     MathError(#[from] MathError),
+
+    #[error("{0}")]
+    SignedDecimal256RangeExceeded(#[from] SignedDecimal256RangeExceeded),
 
     #[error("{0}")]
     TrasnmuterMathError(#[from] transmuter_math::TransmuterMathError),

--- a/contracts/transmuter/src/incentive_pool.rs
+++ b/contracts/transmuter/src/incentive_pool.rs
@@ -234,18 +234,7 @@ impl IncentivePool {
 
         // Then, remove tokens from pool
         for coin in redemptions {
-            let current_balance = self
-                .pool_balances
-                .may_load(storage, coin.denom.clone())?
-                .unwrap_or_default();
-
-            let updated_balance = current_balance.checked_sub(coin.amount)?;
-            if updated_balance.is_zero() {
-                self.pool_balances.remove(storage, coin.denom.clone());
-            } else {
-                self.pool_balances
-                    .save(storage, coin.denom.clone(), &updated_balance)?;
-            }
+            self.remove_tokens(storage, &coin)?;
         }
 
         Ok(())

--- a/contracts/transmuter/src/swap.rs
+++ b/contracts/transmuter/src/swap.rs
@@ -336,15 +336,115 @@ impl Transmuter {
                     token_out_min_amount,
                 )?;
 
+                let mut token_out = coin(out_amount.u128(), token_out_denom);
+                let tokens_out = vec![token_out.clone()];
+
+                let denoms_in_corrupted_asset_group = pool
+                    .asset_groups
+                    .iter()
+                    .flat_map(|(_, asset_group)| {
+                        if asset_group.is_corrupted() {
+                            asset_group.denoms().to_vec()
+                        } else {
+                            vec![]
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                // TODO: move this logic into rebalancing pass
+                let is_force_exit_corrupted_assets = tokens_out.iter().all(|coin| {
+                    let total_liquidity = pool
+                        .get_pool_asset_by_denom(&coin.denom)
+                        .map(|asset| asset.amount())
+                        .unwrap_or_default();
+
+                    let is_redeeming_total_liquidity = coin.amount == total_liquidity;
+                    let is_under_corrupted_asset_group =
+                        denoms_in_corrupted_asset_group.contains(&coin.denom);
+
+                    is_redeeming_total_liquidity
+                        && (is_under_corrupted_asset_group || pool.is_corrupted_asset(&coin.denom))
+                });
+
+                // If all tokens out are corrupted assets and exit with all remaining liquidity
+                // then ignore the limit and remove the corrupted assets from the pool
+                if is_force_exit_corrupted_assets {
+                    pool.unchecked_exit_pool(&tokens_out)?;
+                } else {
+                    let run_pool = |_: Deps, mut pool: TransmuterPool| {
+                        pool.exit_pool(&tokens_out)?;
+                        Ok((pool, token_out))
+                    };
+
+                    let rebalancing_adjustment =
+                        |pool: TransmuterPool, token_out: Coin, total_adjustment_value: Int256| {
+                            let std_norm_factor = pool.std_norm_factor()?;
+                            let token_out_norm_factor = pool
+                                .get_pool_asset_by_denom(token_out_denom)?
+                                .normalization_factor();
+
+                            let (token_out, adjustment) =
+                                match total_adjustment_value.cmp(&Int256::zero()) {
+                                    Ordering::Less => {
+                                        // deduct fee from token_out
+                                        let fee_amount = convert_amount(
+                                            total_adjustment_value.abs().try_into()?,
+                                            std_norm_factor,
+                                            token_out_norm_factor,
+                                            // rounding up means slightly more fee than required, keeps the incentive pool healthy
+                                            &crate::asset::Rounding::Up,
+                                        )?;
+                                        let token_out_amount: Uint128 =
+                                            token_out.amount.checked_sub(fee_amount)?;
+                                        let token_out =
+                                            coin(token_out_amount.u128(), token_out.denom.clone());
+                                        let token_out_denom = token_out.denom.clone();
+
+                                        (
+                                            token_out,
+                                            Adjustment::DeductFee {
+                                                fee: coin(fee_amount.u128(), token_out_denom),
+                                            },
+                                        )
+                                    }
+                                    Ordering::Greater => (
+                                        token_out,
+                                        Adjustment::CreditIncentive {
+                                            incentive: total_adjustment_value.abs().try_into()?,
+                                        },
+                                    ),
+                                    Ordering::Equal => (token_out, Adjustment::None),
+                                };
+
+                            ensure!(
+                                token_out.amount >= token_out_min_amount,
+                                ContractError::InsufficientTokenOut {
+                                    min_required: token_out_min_amount,
+                                    amount_out: token_out.amount,
+                                }
+                            );
+
+                            Ok((token_out, adjustment))
+                        };
+
+                    (pool, token_out, _) = self.rebalancer_pass(
+                        deps.branch(),
+                        pool,
+                        &sender,
+                        run_pool,
+                        rebalancing_adjustment,
+                    )?;
+                }
+
                 let response = set_data_if_sudo(
                     response,
                     &entrypoint,
                     &SwapExactAmountInResponseData {
-                        token_out_amount: out_amount,
+                        token_out_amount: token_out.amount,
                     },
                 )?;
 
-                let tokens_out = vec![coin(out_amount.u128(), token_out_denom)];
+                let tokens_out = vec![token_out];
 
                 (token_in_amount, tokens_out, response)
             }
@@ -354,21 +454,123 @@ impl Transmuter {
             } => {
                 let tokens_out_with_norm_factor =
                     pool.pair_coins_with_normalization_factor(tokens_out)?;
+
+                let token_in_norm_factor =
+                    self.alloyed_asset.get_normalization_factor(deps.storage)?;
                 let in_amount = swap_from_alloyed::in_amount_via_exact_out(
                     token_in_max_amount,
-                    self.alloyed_asset.get_normalization_factor(deps.storage)?,
+                    token_in_norm_factor,
                     tokens_out_with_norm_factor,
                 )?;
+
+                let token_in_denom = self.alloyed_asset.get_alloyed_denom(deps.storage)?;
+                let mut token_in = coin(in_amount.u128(), token_in_denom.clone());
+
+                let denoms_in_corrupted_asset_group = pool
+                    .asset_groups
+                    .iter()
+                    .flat_map(|(_, asset_group)| {
+                        if asset_group.is_corrupted() {
+                            asset_group.denoms().to_vec()
+                        } else {
+                            vec![]
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                let is_force_exit_corrupted_assets = tokens_out.iter().all(|coin| {
+                    let total_liquidity = pool
+                        .get_pool_asset_by_denom(&coin.denom)
+                        .map(|asset| asset.amount())
+                        .unwrap_or_default();
+
+                    let is_redeeming_total_liquidity = coin.amount == total_liquidity;
+                    let is_under_corrupted_asset_group =
+                        denoms_in_corrupted_asset_group.contains(&coin.denom);
+
+                    is_redeeming_total_liquidity
+                        && (is_under_corrupted_asset_group || pool.is_corrupted_asset(&coin.denom))
+                });
+
+                // If all tokens out are corrupted assets and exit with all remaining liquidity
+                // then ignore the limit and remove the corrupted assets from the pool
+                if is_force_exit_corrupted_assets {
+                    pool.unchecked_exit_pool(&tokens_out)?;
+                } else {
+                    let run_pool = |_: Deps, mut pool: TransmuterPool| {
+                        pool.exit_pool(&tokens_out)?;
+                        Ok((pool, token_in.clone()))
+                    };
+
+                    let rebalancing_adjustment =
+                        |pool: TransmuterPool, token_in: Coin, total_adjustment_value: Int256| {
+                            let std_norm_factor = pool.std_norm_factor()?;
+
+                            // If adjustment value is negative, fee take from the token_in, so we require addtional token_in // to pay for the fee.
+                            // Otherwise, return the token_in as is
+                            let (token_in, adjustment) =
+                                match total_adjustment_value.cmp(&Int256::zero()) {
+                                    // negative adjustment value means fee deduction from token_in
+                                    Ordering::Less => {
+                                        let fee = convert_amount(
+                                            total_adjustment_value.abs().try_into()?,
+                                            std_norm_factor,
+                                            token_in_norm_factor,
+                                            // rounding up means slightly more fee than required, keeps the incentive pool healthy
+                                            &crate::asset::Rounding::Up,
+                                        )?;
+
+                                        let token_in_amount = token_in.amount.checked_add(fee)?;
+
+                                        (
+                                            coin(token_in_amount.u128(), token_in.denom.clone()),
+                                            Adjustment::DeductFee {
+                                                fee: coin(fee.u128(), token_in.denom.clone()),
+                                            },
+                                        )
+                                    }
+                                    // positive adjustment value means incentive credit to the beneficiary
+                                    Ordering::Greater => (
+                                        token_in,
+                                        Adjustment::CreditIncentive {
+                                            incentive: total_adjustment_value.abs().try_into()?,
+                                        },
+                                    ),
+                                    // zero adjustment means no adjustment
+                                    Ordering::Equal => (token_in, Adjustment::None),
+                                };
+
+                            let token_in_amount = token_in.amount.clone();
+
+                            ensure!(
+                                token_in_amount <= token_in_max_amount,
+                                ContractError::ExcessiveRequiredTokenIn {
+                                    limit: token_in_max_amount,
+                                    required: token_in_amount,
+                                }
+                            );
+
+                            Ok((token_in, adjustment))
+                        };
+
+                    (pool, token_in, _) = self.rebalancer_pass(
+                        deps.branch(),
+                        pool,
+                        &sender,
+                        run_pool,
+                        rebalancing_adjustment,
+                    )?;
+                }
 
                 let response = set_data_if_sudo(
                     response,
                     &entrypoint,
                     &SwapExactAmountOutResponseData {
-                        token_in_amount: in_amount,
+                        token_in_amount: token_in.amount,
                     },
                 )?;
 
-                (in_amount, tokens_out.to_vec(), response)
+                (token_in.amount, tokens_out.to_vec(), response)
             }
         };
 
@@ -421,52 +623,6 @@ impl Transmuter {
             }
         }?
         .to_string();
-
-        let denoms_in_corrupted_asset_group = pool
-            .asset_groups
-            .iter()
-            .flat_map(|(_, asset_group)| {
-                if asset_group.is_corrupted() {
-                    asset_group.denoms().to_vec()
-                } else {
-                    vec![]
-                }
-            })
-            .collect::<Vec<_>>();
-
-        // TODO: move this logic into rebalancing pass
-        let is_force_exit_corrupted_assets = tokens_out.iter().all(|coin| {
-            let total_liquidity = pool
-                .get_pool_asset_by_denom(&coin.denom)
-                .map(|asset| asset.amount())
-                .unwrap_or_default();
-
-            let is_redeeming_total_liquidity = coin.amount == total_liquidity;
-            let is_under_corrupted_asset_group =
-                denoms_in_corrupted_asset_group.contains(&coin.denom);
-
-            is_redeeming_total_liquidity
-                && (is_under_corrupted_asset_group || pool.is_corrupted_asset(&coin.denom))
-        });
-
-        // If all tokens out are corrupted assets and exit with all remaining liquidity
-        // then ignore the limit and remove the corrupted assets from the pool
-        if is_force_exit_corrupted_assets {
-            // TODO: Do we need to handle incentive here still?
-            pool.unchecked_exit_pool(&tokens_out)?;
-        } else {
-            (pool, _, _) = self.rebalancer_pass(
-                deps.branch(),
-                pool,
-                &sender,
-                |_, mut pool| {
-                    pool.exit_pool(&tokens_out)?;
-                    // TODO: add fee deduction  / incentive credit here
-                    Ok((pool, ()))
-                },
-                |_, output, _| Ok((output, Adjustment::None)),
-            )?;
-        }
 
         self.clean_up_drained_corrupted_assets(deps.storage, &mut pool)?;
 
@@ -847,8 +1003,6 @@ impl Transmuter {
                             updated_weight,
                             rebalancing_config.clone(),
                         )?;
-
-                        dbg!(scope, prev_weight, updated_weight, adjustment);
 
                         total_adjustment_rate = total_adjustment_rate.checked_add(adjustment)?;
                     }

--- a/contracts/transmuter/src/swap.rs
+++ b/contracts/transmuter/src/swap.rs
@@ -2235,8 +2235,8 @@ mod tests {
         let res = transmuter.swap_non_alloyed_exact_amount_out(
             token_in_denom,
             token_in_amount,
-            token_out,
-            sender,
+            token_out.clone(),
+            sender.clone(),
             deps.as_mut(),
         );
 
@@ -2272,6 +2272,93 @@ mod tests {
             .get_all_incentive_credits(&deps.storage, None, None)
             .unwrap();
         assert_eq!(credits, vec![]);
+
+        // swap back with the same amount
+        let res = transmuter
+            .swap_non_alloyed_exact_amount_in(
+                token_out,
+                "denom1",
+                amount_in_before_fee,
+                sender.clone(),
+                deps.as_mut(),
+            )
+            .unwrap();
+        let data: SwapExactAmountInResponseData = from_json(&res.data.unwrap()).unwrap();
+        assert_eq!(
+            data,
+            SwapExactAmountInResponseData {
+                token_out_amount: amount_in_before_fee,
+            }
+        );
+
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+
+        assert_eq!(
+            pool.pool_assets,
+            vec![
+                Asset::new(Uint128::from(100_000_000_000u128), "denom1", 1u128).unwrap(),
+                Asset::new(Uint128::from(500_000_000_000u128), "denom2", 10u128).unwrap(),
+                Asset::new(Uint128::from(5_000_000_000_000u128), "denom3", 100u128).unwrap(),
+            ]
+        );
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+        assert_eq!(
+            credits,
+            vec![(sender.clone(), fee * Uint128::from(100u128))]
+        );
+
+        let pool_denom_factors = pool
+            .pool_assets
+            .iter()
+            .map(|asset| (asset.denom().to_string(), asset.normalization_factor()))
+            .collect::<BTreeMap<_, _>>();
+
+        let err = transmuter
+            .incentive_pool
+            .redeem_incentive(
+                &mut deps.storage,
+                &sender,
+                vec![coin(fee.u128() + 1, "denom1")],
+                &pool_denom_factors,
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            ContractError::InsufficientIncentiveCredit {
+                user: sender.clone(),
+                available: fee * Uint128::from(100u128),
+                requested: (fee + Uint128::from(1u128)) * Uint128::from(100u128),
+            }
+        );
+
+        transmuter
+            .incentive_pool
+            .redeem_incentive(
+                &mut deps.storage,
+                &sender,
+                vec![coin(fee.u128(), "denom1")],
+                &pool_denom_factors,
+            )
+            .unwrap();
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+
+        assert_eq!(credits, vec![]);
+
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+
+        assert_eq!(incentive_pool_balances, vec![]);
     }
 
     #[test]
@@ -2304,10 +2391,10 @@ mod tests {
         );
 
         let res = transmuter.swap_non_alloyed_exact_amount_in(
-            token_in,
+            token_in.clone(),
             "denom2",
             token_out_amount,
-            sender,
+            sender.clone(),
             deps.as_mut(),
         );
 
@@ -2343,5 +2430,89 @@ mod tests {
             .get_all_incentive_credits(&deps.storage, None, None)
             .unwrap();
         assert_eq!(credits, vec![]);
+
+        // swap back with the same amount
+        let res = transmuter.swap_non_alloyed_exact_amount_out(
+            "denom2",
+            amount_out_before_fee,
+            token_in,
+            sender.clone(),
+            deps.as_mut(),
+        );
+
+        let data: SwapExactAmountOutResponseData = from_json(&res.unwrap().data.unwrap()).unwrap();
+        assert_eq!(
+            data,
+            SwapExactAmountOutResponseData {
+                token_in_amount: amount_out_before_fee,
+            }
+        );
+
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+
+        assert_eq!(
+            pool.pool_assets,
+            vec![
+                Asset::new(Uint128::from(100_000_000_000u128), "denom1", 1u128).unwrap(),
+                Asset::new(Uint128::from(500_000_000_000u128), "denom2", 10u128).unwrap(),
+                Asset::new(Uint128::from(5_000_000_000_000u128), "denom3", 100u128).unwrap(),
+            ]
+        );
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+
+        assert_eq!(credits, vec![(sender.clone(), fee * Uint128::from(10u128))]);
+
+        let pool_denom_factors = pool
+            .pool_assets
+            .iter()
+            .map(|asset| (asset.denom().to_string(), asset.normalization_factor()))
+            .collect::<BTreeMap<_, _>>();
+
+        let err = transmuter
+            .incentive_pool
+            .redeem_incentive(
+                &mut deps.storage,
+                &sender,
+                vec![coin(fee.u128() + 1, "denom2")],
+                &pool_denom_factors,
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            ContractError::InsufficientIncentiveCredit {
+                user: sender.clone(),
+                available: fee * Uint128::from(10u128),
+                requested: (fee + Uint128::from(1u128)) * Uint128::from(10u128),
+            }
+        );
+
+        transmuter
+            .incentive_pool
+            .redeem_incentive(
+                &mut deps.storage,
+                &sender,
+                vec![coin(fee.u128(), "denom2")],
+                &pool_denom_factors,
+            )
+            .unwrap();
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+
+        assert_eq!(credits, vec![]);
+
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+
+        assert_eq!(incentive_pool_balances, vec![]);
     }
 }

--- a/contracts/transmuter/src/swap.rs
+++ b/contracts/transmuter/src/swap.rs
@@ -6,11 +6,11 @@ use std::{
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     coin, ensure, ensure_eq, to_json_binary, Addr, BankMsg, Coin, Decimal, Deps, DepsMut, Env,
-    Int256, Response, StdError, Storage, Uint128,
+    Int256, Response, SignedDecimal256, StdError, Storage, Uint128,
 };
 use osmosis_std::types::osmosis::tokenfactory::v1beta1::{MsgBurn, MsgMint};
 use serde::Serialize;
-use transmuter_math::rebalancing::compute_adjustment_value;
+use transmuter_math::rebalancing::{compute_total_effective_adjustment_rate, round_adjustment};
 
 use crate::{
     alloyed_asset::{swap_from_alloyed, swap_to_alloyed},
@@ -671,8 +671,14 @@ impl Transmuter {
         // output is token_out for exact_in, token_in for exact_out
         let (pool, output, rebalancing_adjustment) = run_pool(deps.as_ref(), pool)?;
 
+        // balance_total is the total normalized amount of the asset in the pool
+        let balance_total = pool
+            .normalized_asset_values(pool.std_norm_factor()?)?
+            .into_iter()
+            .try_fold(Uint128::zero(), |acc, (_, value)| acc.checked_add(value))?;
+
         // check limits only if pool assets are not zero, calculate adjustment value
-        let mut total_adjustment_value = Int256::zero();
+        let mut total_adjustment_rate = SignedDecimal256::zero();
         if let Some(updated_asset_weights) = pool.asset_weights()? {
             if let Some(updated_asset_group_weights) = pool.asset_group_weights()? {
                 let scope_value_pairs = construct_scope_value_pairs(
@@ -682,23 +688,17 @@ impl Transmuter {
                     updated_asset_group_weights,
                 )?;
 
-                // balance_total is the total normalized amount of the asset in the pool
-                let balance_total = pool
-                    .normalized_asset_values(pool.std_norm_factor()?)?
-                    .into_iter()
-                    .try_fold(Uint128::zero(), |acc, (_, value)| acc.checked_add(value))?;
-
                 for (scope, (prev_weight, updated_weight)) in scope_value_pairs.clone() {
                     let rebalancing_configs =
                         self.rebalancer.get_config_by_scope(deps.storage, &scope)?;
                     if let Some(rebalancing_config) = rebalancing_configs {
-                        total_adjustment_value =
-                            total_adjustment_value.checked_add(compute_adjustment_value(
-                                prev_weight,
-                                updated_weight,
-                                balance_total,
-                                rebalancing_config,
-                            )?)?;
+                        let adjustment = compute_total_effective_adjustment_rate(
+                            prev_weight,
+                            updated_weight,
+                            rebalancing_config,
+                        )?;
+
+                        total_adjustment_rate = total_adjustment_rate.checked_add(adjustment)?;
                     }
                 }
 
@@ -707,7 +707,12 @@ impl Transmuter {
             }
         }
 
-        let (output, adjustment) = rebalancing_adjustment(output, total_adjustment_value)?;
+        let total_adjustment_value = total_adjustment_rate.checked_mul(
+            SignedDecimal256::from_atomics(Int256::from(balance_total), 0)?,
+        )?;
+
+        let (output, adjustment) =
+            rebalancing_adjustment(output, round_adjustment(total_adjustment_value)?)?;
 
         match adjustment {
             Adjustment::DeductFee { fee } => {

--- a/contracts/transmuter/src/swap.rs
+++ b/contracts/transmuter/src/swap.rs
@@ -87,64 +87,70 @@ impl Transmuter {
                 // - fee case: we deduct fee from out_amount
                 // - incentive case: we credit incentive to the beneficiary
 
-                let (pool, token_out, adjustment) =
-                    self.rebalancer_pass(deps.branch(), pool, &mint_to_address, |_, mut pool| {
-                        pool.join_pool(&tokens_in)?;
+                let run_pool = |_deps: Deps, mut pool: TransmuterPool| {
+                    pool.join_pool(&tokens_in)?;
+                    let token_out = coin(out_amount_before_fee.u128(), alloyed_denom.clone());
 
+                    Ok((pool, token_out))
+                };
+
+                let rebalancing_adjustment =
+                    |pool: TransmuterPool, token_out: Coin, total_adjustment_value: Int256| {
                         let std_norm_factor = pool.std_norm_factor()?;
                         let token_out_norm_factor = alloyed_norm_factor;
-                        let token_out = coin(out_amount_before_fee.u128(), alloyed_denom);
 
-                        let rebalancing_adjustment =
-                            move |token_out: Coin, total_adjustment_value: Int256| {
-                                let (token_out, adjustment) = match total_adjustment_value
-                                    .cmp(&Int256::zero())
-                                {
-                                    Ordering::Less => {
-                                        // deduct fee from token_out
-                                        let fee_amount = convert_amount(
-                                            total_adjustment_value.abs().try_into()?,
-                                            std_norm_factor,
-                                            token_out_norm_factor,
-                                            // rounding up means slightly more fee than required, keeps the incentive pool healthy
-                                            &crate::asset::Rounding::Up,
-                                        )?;
+                        let (token_out, adjustment) =
+                            match total_adjustment_value.cmp(&Int256::zero()) {
+                                Ordering::Less => {
+                                    // deduct fee from token_out
+                                    let fee_amount = convert_amount(
+                                        total_adjustment_value.abs().try_into()?,
+                                        std_norm_factor,
+                                        token_out_norm_factor,
+                                        // rounding up means slightly more fee than required, keeps the incentive pool healthy
+                                        &crate::asset::Rounding::Up,
+                                    )?;
 
-                                        let token_out_amount: Uint128 =
-                                            token_out.amount.checked_sub(fee_amount)?;
-                                        let token_out =
-                                            coin(token_out_amount.u128(), token_out.denom.clone());
-                                        let token_out_denom = token_out.denom.clone();
+                                    let token_out_amount: Uint128 =
+                                        token_out.amount.checked_sub(fee_amount)?;
+                                    let token_out =
+                                        coin(token_out_amount.u128(), token_out.denom.clone());
+                                    let token_out_denom = token_out.denom.clone();
 
-                                        (
-                                            token_out,
-                                            Adjustment::DeductFee {
-                                                fee: coin(fee_amount.u128(), token_out_denom),
-                                            },
-                                        )
-                                    }
-                                    Ordering::Greater => (
+                                    (
                                         token_out,
-                                        Adjustment::CreditIncentive {
-                                            incentive: total_adjustment_value.abs().try_into()?,
+                                        Adjustment::DeductFee {
+                                            fee: coin(fee_amount.u128(), token_out_denom),
                                         },
-                                    ),
-                                    Ordering::Equal => (token_out, Adjustment::None),
-                                };
-
-                                ensure!(
-                                    token_out.amount >= token_out_min_amount,
-                                    ContractError::InsufficientTokenOut {
-                                        min_required: token_out_min_amount,
-                                        amount_out: token_out.amount,
-                                    }
-                                );
-
-                                Ok((token_out, adjustment))
+                                    )
+                                }
+                                Ordering::Greater => (
+                                    token_out,
+                                    Adjustment::CreditIncentive {
+                                        incentive: total_adjustment_value.abs().try_into()?,
+                                    },
+                                ),
+                                Ordering::Equal => (token_out, Adjustment::None),
                             };
 
-                        Ok((pool, token_out, rebalancing_adjustment))
-                    })?;
+                        ensure!(
+                            token_out.amount >= token_out_min_amount,
+                            ContractError::InsufficientTokenOut {
+                                min_required: token_out_min_amount,
+                                amount_out: token_out.amount,
+                            }
+                        );
+
+                        Ok((token_out, adjustment))
+                    };
+
+                let (pool, token_out, adjustment) = self.rebalancer_pass(
+                    deps.branch(),
+                    pool,
+                    &mint_to_address,
+                    run_pool,
+                    rebalancing_adjustment,
+                )?;
 
                 let response = set_data_if_sudo(
                     response,
@@ -185,68 +191,75 @@ impl Transmuter {
                 )?;
                 let token_in = coin(in_amount_before_fee.u128(), token_in_denom);
 
-                // if it's exact_out
-                // - fee case: we increase tokens in requirement, it's spreaded through all the tokens in
-                // - incentive case: we credit incentive to the beneficiary
-                let (pool, token_in, _adjustment) =
-                    self.rebalancer_pass(deps.branch(), pool, &mint_to_address, |_, mut pool| {
-                        pool.join_pool(&[token_in.clone()])?;
+                let run_pool = |_deps: Deps, mut pool: TransmuterPool| {
+                    pool.join_pool(&[token_in.clone()])?;
+                    Ok((pool, token_in))
+                };
+
+                let rebalancing_adjustment =
+                    move |pool: TransmuterPool, token_in: Coin, total_adjustment_value: Int256| {
                         let std_norm_factor = pool.std_norm_factor()?;
                         let token_in_norm_factor = pool
                             .get_pool_asset_by_denom(&token_in_denom)?
                             .normalization_factor();
 
-                        let rebalancing_adjustment =
-                            move |token_in: Coin, total_adjustment_value: Int256| {
-                                // If adjustment value is negative, fee take from the token_in, so we require addtional token_in to pay for the fee.
-                                // Otherwise, return the token_in as is
-                                let (token_in, adjustment) = match total_adjustment_value
-                                    .cmp(&Int256::zero())
-                                {
-                                    // negative adjustment value means fee deduction from token_in
-                                    Ordering::Less => {
-                                        let fee = convert_amount(
-                                            total_adjustment_value.abs().try_into()?,
-                                            std_norm_factor,
-                                            token_in_norm_factor,
-                                            // rounding up means slightly more fee than required, keeps the incentive pool healthy
-                                            &crate::asset::Rounding::Up,
-                                        )?;
+                        // If adjustment value is negative, fee take from the token_in, so we require addtional token_in to pay for the fee.
+                        // Otherwise, return the token_in as is
+                        let (token_in, adjustment) =
+                            match total_adjustment_value.cmp(&Int256::zero()) {
+                                // negative adjustment value means fee deduction from token_in
+                                Ordering::Less => {
+                                    let fee = convert_amount(
+                                        total_adjustment_value.abs().try_into()?,
+                                        std_norm_factor,
+                                        token_in_norm_factor,
+                                        // rounding up means slightly more fee than required, keeps the incentive pool healthy
+                                        &crate::asset::Rounding::Up,
+                                    )?;
 
-                                        let token_in_amount = token_in.amount.checked_add(fee)?;
+                                    let token_in_amount = token_in.amount.checked_add(fee)?;
 
-                                        (
-                                            coin(token_in_amount.u128(), token_in.denom.clone()),
-                                            Adjustment::DeductFee {
-                                                fee: coin(fee.u128(), token_in.denom.clone()),
-                                            },
-                                        )
-                                    }
-                                    // positive adjustment value means incentive credit to the beneficiary
-                                    Ordering::Greater => (
-                                        token_in,
-                                        Adjustment::CreditIncentive {
-                                            incentive: total_adjustment_value.abs().try_into()?,
+                                    (
+                                        coin(token_in_amount.u128(), token_in.denom.clone()),
+                                        Adjustment::DeductFee {
+                                            fee: coin(fee.u128(), token_in.denom.clone()),
                                         },
-                                    ),
-                                    // zero adjustment means no adjustment
-                                    Ordering::Equal => (token_in, Adjustment::None),
-                                };
-
-                                let token_in_amount = token_in.amount.clone();
-
-                                ensure!(
-                                    token_in_amount <= token_in_max_amount,
-                                    ContractError::ExcessiveRequiredTokenIn {
-                                        limit: token_in_max_amount,
-                                        required: token_in_amount,
-                                    }
-                                );
-
-                                Ok((token_in, adjustment))
+                                    )
+                                }
+                                // positive adjustment value means incentive credit to the beneficiary
+                                Ordering::Greater => (
+                                    token_in,
+                                    Adjustment::CreditIncentive {
+                                        incentive: total_adjustment_value.abs().try_into()?,
+                                    },
+                                ),
+                                // zero adjustment means no adjustment
+                                Ordering::Equal => (token_in, Adjustment::None),
                             };
-                        Ok((pool, token_in, rebalancing_adjustment))
-                    })?;
+
+                        let token_in_amount = token_in.amount.clone();
+
+                        ensure!(
+                            token_in_amount <= token_in_max_amount,
+                            ContractError::ExcessiveRequiredTokenIn {
+                                limit: token_in_max_amount,
+                                required: token_in_amount,
+                            }
+                        );
+
+                        Ok((token_in, adjustment))
+                    };
+
+                // if it's exact_out
+                // - fee case: we increase tokens in requirement, it's spreaded through all the tokens in
+                // - incentive case: we credit incentive to the beneficiary
+                let (pool, token_in, _adjustment) = self.rebalancer_pass(
+                    deps.branch(),
+                    pool,
+                    &mint_to_address,
+                    run_pool,
+                    rebalancing_adjustment,
+                )?;
 
                 // Unlike exact in case where token out is alloyed, there is no separate mint target required here
                 // Because fee is collected from the token_in
@@ -442,13 +455,17 @@ impl Transmuter {
             // TODO: Do we need to handle incentive here still?
             pool.unchecked_exit_pool(&tokens_out)?;
         } else {
-            (pool, _, _) = self.rebalancer_pass(deps.branch(), pool, &sender, |_, mut pool| {
-                pool.exit_pool(&tokens_out)?;
-                // TODO: add fee deduction  / incentive credit here
-                Ok((pool, (), |output, total_adjustment_value| {
-                    Ok((output, Adjustment::None))
-                }))
-            })?;
+            (pool, _, _) = self.rebalancer_pass(
+                deps.branch(),
+                pool,
+                &sender,
+                |_, mut pool| {
+                    pool.exit_pool(&tokens_out)?;
+                    // TODO: add fee deduction  / incentive credit here
+                    Ok((pool, ()))
+                },
+                |_, output, _| Ok((output, Adjustment::None)),
+            )?;
         }
 
         self.clean_up_drained_corrupted_assets(deps.storage, &mut pool)?;
@@ -486,64 +503,65 @@ impl Transmuter {
     ) -> Result<Response, ContractError> {
         let pool = self.pool.load(deps.storage)?;
 
-        let (mut pool, actual_token_out, _adjustment) =
-            self.rebalancer_pass(deps.branch(), pool, &sender, |deps, pool| {
-                let (pool, token_out) =
-                    self.out_amt_given_in(deps, pool, token_in, token_out_denom)?;
+        let run_pool = |deps: Deps, pool: TransmuterPool| {
+            self.out_amt_given_in(deps, pool, token_in, token_out_denom)
+        };
 
+        let rebalancing_adjustment =
+            |pool: TransmuterPool, token_out: Coin, total_adjustment_value: Int256| {
                 let std_norm_factor = pool.std_norm_factor()?;
                 let token_out_norm_factor = pool
                     .get_pool_asset_by_denom(token_out_denom)?
                     .normalization_factor();
 
-                let rebalancing_adjustment =
-                    move |token_out: Coin, total_adjustment_value: Int256| {
-                        let (token_out, adjustment) =
-                            match total_adjustment_value.cmp(&Int256::zero()) {
-                                Ordering::Less => {
-                                    // deduct fee from token_out
-                                    let fee_amount = convert_amount(
-                                        total_adjustment_value.abs().try_into()?,
-                                        std_norm_factor,
-                                        token_out_norm_factor,
-                                        // rounding up means slightly more fee than required, keeps the incentive pool healthy
-                                        &crate::asset::Rounding::Up,
-                                    )?;
-                                    let token_out_amount: Uint128 =
-                                        token_out.amount.checked_sub(fee_amount)?;
-                                    let token_out =
-                                        coin(token_out_amount.u128(), token_out.denom.clone());
-                                    let token_out_denom = token_out.denom.clone();
+                let (token_out, adjustment) = match total_adjustment_value.cmp(&Int256::zero()) {
+                    Ordering::Less => {
+                        // deduct fee from token_out
+                        let fee_amount = convert_amount(
+                            total_adjustment_value.abs().try_into()?,
+                            std_norm_factor,
+                            token_out_norm_factor,
+                            // rounding up means slightly more fee than required, keeps the incentive pool healthy
+                            &crate::asset::Rounding::Up,
+                        )?;
+                        let token_out_amount: Uint128 = token_out.amount.checked_sub(fee_amount)?;
+                        let token_out = coin(token_out_amount.u128(), token_out.denom.clone());
+                        let token_out_denom = token_out.denom.clone();
 
-                                    (
-                                        token_out,
-                                        Adjustment::DeductFee {
-                                            fee: coin(fee_amount.u128(), token_out_denom),
-                                        },
-                                    )
-                                }
-                                Ordering::Greater => (
-                                    token_out,
-                                    Adjustment::CreditIncentive {
-                                        incentive: total_adjustment_value.abs().try_into()?,
-                                    },
-                                ),
-                                Ordering::Equal => (token_out, Adjustment::None),
-                            };
+                        (
+                            token_out,
+                            Adjustment::DeductFee {
+                                fee: coin(fee_amount.u128(), token_out_denom),
+                            },
+                        )
+                    }
+                    Ordering::Greater => (
+                        token_out,
+                        Adjustment::CreditIncentive {
+                            incentive: total_adjustment_value.abs().try_into()?,
+                        },
+                    ),
+                    Ordering::Equal => (token_out, Adjustment::None),
+                };
 
-                        ensure!(
-                            token_out.amount >= token_out_min_amount,
-                            ContractError::InsufficientTokenOut {
-                                min_required: token_out_min_amount,
-                                amount_out: token_out.amount,
-                            }
-                        );
+                ensure!(
+                    token_out.amount >= token_out_min_amount,
+                    ContractError::InsufficientTokenOut {
+                        min_required: token_out_min_amount,
+                        amount_out: token_out.amount,
+                    }
+                );
 
-                        Ok((token_out, adjustment))
-                    };
+                Ok((token_out, adjustment))
+            };
 
-                Ok((pool, token_out, rebalancing_adjustment))
-            })?;
+        let (mut pool, actual_token_out, _adjustment) = self.rebalancer_pass(
+            deps.branch(),
+            pool,
+            &sender,
+            run_pool,
+            rebalancing_adjustment,
+        )?;
 
         self.clean_up_drained_corrupted_assets(deps.storage, &mut pool)?;
 
@@ -574,71 +592,70 @@ impl Transmuter {
     ) -> Result<Response, ContractError> {
         let pool = self.pool.load(deps.storage)?;
 
-        let (mut pool, actual_token_in, _adjustment) =
-            self.rebalancer_pass(deps.branch(), pool, &sender, |deps, pool| {
-                let (pool, token_in) = self.in_amt_given_out(
-                    deps,
-                    pool,
-                    token_out.clone(),
-                    token_in_denom.to_string(),
-                )?;
+        let run_pool = |deps: Deps, pool: TransmuterPool| {
+            self.in_amt_given_out(deps, pool, token_out.clone(), token_in_denom.to_string())
+        };
 
+        let rebalancing_adjustment =
+            |pool: TransmuterPool, token_in: Coin, total_adjustment_value: Int256| {
                 let std_norm_factor = pool.std_norm_factor()?;
                 let token_in_norm_factor = pool
                     .get_pool_asset_by_denom(&token_in_denom)?
                     .normalization_factor();
 
-                let rebalancing_adjustment =
-                    move |token_in: Coin, total_adjustment_value: Int256| {
-                        // If adjustment value is negative, fee take from the token_in, so we require addtional token_in // to pay for the fee.
-                        // Otherwise, return the token_in as is
-                        let (token_in, adjustment) =
-                            match total_adjustment_value.cmp(&Int256::zero()) {
-                                // negative adjustment value means fee deduction from token_in
-                                Ordering::Less => {
-                                    let fee = convert_amount(
-                                        total_adjustment_value.abs().try_into()?,
-                                        std_norm_factor,
-                                        token_in_norm_factor,
-                                        // rounding up means slightly more fee than required, keeps the incentive pool healthy
-                                        &crate::asset::Rounding::Up,
-                                    )?;
+                // If adjustment value is negative, fee take from the token_in, so we require addtional token_in // to pay for the fee.
+                // Otherwise, return the token_in as is
+                let (token_in, adjustment) = match total_adjustment_value.cmp(&Int256::zero()) {
+                    // negative adjustment value means fee deduction from token_in
+                    Ordering::Less => {
+                        let fee = convert_amount(
+                            total_adjustment_value.abs().try_into()?,
+                            std_norm_factor,
+                            token_in_norm_factor,
+                            // rounding up means slightly more fee than required, keeps the incentive pool healthy
+                            &crate::asset::Rounding::Up,
+                        )?;
 
-                                    let token_in_amount = token_in.amount.checked_add(fee)?;
+                        let token_in_amount = token_in.amount.checked_add(fee)?;
 
-                                    (
-                                        coin(token_in_amount.u128(), token_in.denom.clone()),
-                                        Adjustment::DeductFee {
-                                            fee: coin(fee.u128(), token_in.denom.clone()),
-                                        },
-                                    )
-                                }
-                                // positive adjustment value means incentive credit to the beneficiary
-                                Ordering::Greater => (
-                                    token_in,
-                                    Adjustment::CreditIncentive {
-                                        incentive: total_adjustment_value.abs().try_into()?,
-                                    },
-                                ),
-                                // zero adjustment means no adjustment
-                                Ordering::Equal => (token_in, Adjustment::None),
-                            };
+                        (
+                            coin(token_in_amount.u128(), token_in.denom.clone()),
+                            Adjustment::DeductFee {
+                                fee: coin(fee.u128(), token_in.denom.clone()),
+                            },
+                        )
+                    }
+                    // positive adjustment value means incentive credit to the beneficiary
+                    Ordering::Greater => (
+                        token_in,
+                        Adjustment::CreditIncentive {
+                            incentive: total_adjustment_value.abs().try_into()?,
+                        },
+                    ),
+                    // zero adjustment means no adjustment
+                    Ordering::Equal => (token_in, Adjustment::None),
+                };
 
-                        let token_in_amount = token_in.amount.clone();
+                let token_in_amount = token_in.amount.clone();
 
-                        ensure!(
-                            token_in_amount <= token_in_max_amount,
-                            ContractError::ExcessiveRequiredTokenIn {
-                                limit: token_in_max_amount,
-                                required: token_in_amount,
-                            }
-                        );
+                ensure!(
+                    token_in_amount <= token_in_max_amount,
+                    ContractError::ExcessiveRequiredTokenIn {
+                        limit: token_in_max_amount,
+                        required: token_in_amount,
+                    }
+                );
 
-                        Ok((token_in, adjustment))
-                    };
+                Ok((token_in, adjustment))
+            };
 
-                Ok((pool, token_in, rebalancing_adjustment))
-            })?;
+        let (mut pool, actual_token_in, _adjustment) = self.rebalancer_pass(
+            deps.branch(),
+            pool,
+            &sender,
+            run_pool,
+            rebalancing_adjustment,
+        )?;
 
         self.clean_up_drained_corrupted_assets(deps.storage, &mut pool)?;
 
@@ -787,16 +804,17 @@ impl Transmuter {
         pool: TransmuterPool,
         beneficiary: &Addr,
         run_pool: RunPool,
+        rebalancing_adjustment: RebalancingAdjustment,
     ) -> Result<(TransmuterPool, RunPoolOutput, Adjustment), ContractError>
     where
         RunPool:
-            FnOnce(
-                Deps,
-                TransmuterPool,
-            )
-                -> Result<(TransmuterPool, RunPoolOutput, RebalancingAdjustment), ContractError>,
-        RebalancingAdjustment:
-            FnOnce(RunPoolOutput, Int256) -> Result<(RunPoolOutput, Adjustment), ContractError>,
+            FnOnce(Deps, TransmuterPool) -> Result<(TransmuterPool, RunPoolOutput), ContractError>,
+        RebalancingAdjustment: FnOnce(
+            TransmuterPool,
+            RunPoolOutput,
+            Int256,
+        )
+            -> Result<(RunPoolOutput, Adjustment), ContractError>,
     {
         let prev_asset_weights = pool.asset_weights()?.unwrap_or_default();
         let prev_asset_group_weights = pool.asset_group_weights()?.unwrap_or_default();
@@ -804,8 +822,7 @@ impl Transmuter {
         // total normalized amount of the asset in the pool
         let total_balance_before = pool.normalized_total_balance()?;
 
-        // **** TODO: separated rebalancing_adjustment into another function to pass in here, instead of this saga-like pattern
-        let (pool, output, rebalancing_adjustment) = run_pool(deps.as_ref(), pool)?;
+        let (pool, output) = run_pool(deps.as_ref(), pool)?;
 
         // in case one of token in or out is alloyed, balance_total is updated
         let total_balance_after = pool.normalized_total_balance()?;
@@ -866,8 +883,11 @@ impl Transmuter {
         let total_balance = SignedDecimal256::from_atomics(Int256::from(total_balance), 0)?;
         let total_adjustment_value = total_adjustment_rate.checked_mul(total_balance)?;
 
-        let (output, adjustment) =
-            rebalancing_adjustment(output, round_adjustment(total_adjustment_value)?)?;
+        let (output, adjustment) = rebalancing_adjustment(
+            pool.clone(),
+            output,
+            round_adjustment(total_adjustment_value)?,
+        )?;
 
         match adjustment {
             Adjustment::DeductFee { ref fee } => {
@@ -2974,3 +2994,8 @@ mod tests {
         assert_eq!(credits, vec![(sender, Uint128::from(500_000_000_000u128))]);
     }
 }
+
+// TODO:
+// - separated rebalancing_adjustment into another function to pass in here, instead of this saga-like pattern
+// - complete swap_alloyed_asset_to_tokens
+// - integration test for alloyed case

--- a/contracts/transmuter/src/swap.rs
+++ b/contracts/transmuter/src/swap.rs
@@ -3541,8 +3541,3 @@ mod tests {
         );
     }
 }
-
-// TODO:
-// - separated rebalancing_adjustment into another function to pass in here, instead of this saga-like pattern
-// - complete swap_alloyed_asset_to_tokens
-// - integration test for alloyed case

--- a/contracts/transmuter/src/swap.rs
+++ b/contracts/transmuter/src/swap.rs
@@ -63,32 +63,110 @@ impl Transmuter {
         mut deps: DepsMut,
         env: Env,
     ) -> Result<Response, ContractError> {
-        let mut pool: TransmuterPool = self.pool.load(deps.storage)?;
+        let pool: TransmuterPool = self.pool.load(deps.storage)?;
+        let alloyed_denom = self.alloyed_asset.get_alloyed_denom(deps.storage)?;
+        let alloyed_norm_factor = self.alloyed_asset.get_normalization_factor(deps.storage)?;
 
         let response = Response::new();
 
-        let (tokens_in, out_amount, response) = match constraint {
+        let (pool, tokens_in, out_amount, response) = match constraint {
             SwapToAlloyedConstraint::ExactIn {
                 tokens_in,
                 token_out_min_amount,
             } => {
                 let tokens_in_with_norm_factor =
                     pool.pair_coins_with_normalization_factor(tokens_in)?;
-                let out_amount = swap_to_alloyed::out_amount_via_exact_in(
+                let out_amount_before_fee = swap_to_alloyed::out_amount_via_exact_in(
                     tokens_in_with_norm_factor,
                     token_out_min_amount,
                     self.alloyed_asset.get_normalization_factor(deps.storage)?,
                 )?;
 
+                // we have now calculated tokens_in, out_amount (which is alloyed)
+                // if it's exact_in:
+                // - fee case: we deduct fee from out_amount
+                // - incentive case: we credit incentive to the beneficiary
+
+                let (pool, token_out, adjustment) =
+                    self.rebalancer_pass(deps.branch(), pool, &mint_to_address, |_, mut pool| {
+                        pool.join_pool(&tokens_in)?;
+
+                        let std_norm_factor = pool.std_norm_factor()?;
+                        let token_out_norm_factor = alloyed_norm_factor;
+                        let token_out = coin(out_amount_before_fee.u128(), alloyed_denom);
+
+                        let rebalancing_adjustment =
+                            move |token_out: Coin, total_adjustment_value: Int256| {
+                                let (token_out, adjustment) = match total_adjustment_value
+                                    .cmp(&Int256::zero())
+                                {
+                                    Ordering::Less => {
+                                        // deduct fee from token_out
+                                        let fee_amount = convert_amount(
+                                            total_adjustment_value.abs().try_into()?,
+                                            std_norm_factor,
+                                            token_out_norm_factor,
+                                            // rounding up means slightly more fee than required, keeps the incentive pool healthy
+                                            &crate::asset::Rounding::Up,
+                                        )?;
+
+                                        let token_out_amount: Uint128 =
+                                            token_out.amount.checked_sub(fee_amount)?;
+                                        let token_out =
+                                            coin(token_out_amount.u128(), token_out.denom.clone());
+                                        let token_out_denom = token_out.denom.clone();
+
+                                        (
+                                            token_out,
+                                            Adjustment::DeductFee {
+                                                fee: coin(fee_amount.u128(), token_out_denom),
+                                            },
+                                        )
+                                    }
+                                    Ordering::Greater => (
+                                        token_out,
+                                        Adjustment::CreditIncentive {
+                                            incentive: total_adjustment_value.abs().try_into()?,
+                                        },
+                                    ),
+                                    Ordering::Equal => (token_out, Adjustment::None),
+                                };
+
+                                ensure!(
+                                    token_out.amount >= token_out_min_amount,
+                                    ContractError::InsufficientTokenOut {
+                                        min_required: token_out_min_amount,
+                                        amount_out: token_out.amount,
+                                    }
+                                );
+
+                                Ok((token_out, adjustment))
+                            };
+
+                        Ok((pool, token_out, rebalancing_adjustment))
+                    })?;
+
                 let response = set_data_if_sudo(
                     response,
                     &entrypoint,
                     &SwapExactAmountInResponseData {
-                        token_out_amount: out_amount,
+                        token_out_amount: token_out.amount,
                     },
                 )?;
 
-                (tokens_in.to_owned(), out_amount, response)
+                let response = match adjustment {
+                    // fee is deducted from the minting token out, mint directly to the contract as it's already recorded as such in the incentive pool
+                    Adjustment::DeductFee { fee } => response.add_message(MsgMint {
+                        sender: env.contract.address.to_string(),
+                        amount: Some(fee.into()),
+                        mint_to_address: env.contract.address.to_string(),
+                    }),
+                    // incentive doesn't require minting or burning anything
+                    Adjustment::CreditIncentive { .. } => response,
+                    Adjustment::None => response,
+                };
+
+                (pool, tokens_in.to_owned(), token_out.amount, response)
             }
 
             SwapToAlloyedConstraint::ExactOut {
@@ -99,23 +177,88 @@ impl Transmuter {
                 let token_in_norm_factor = pool
                     .get_pool_asset_by_denom(token_in_denom)?
                     .normalization_factor();
-                let in_amount = swap_to_alloyed::in_amount_via_exact_out(
+                let in_amount_before_fee = swap_to_alloyed::in_amount_via_exact_out(
                     token_in_norm_factor,
                     token_in_max_amount,
                     token_out_amount,
                     self.alloyed_asset.get_normalization_factor(deps.storage)?,
                 )?;
-                let tokens_in = vec![coin(in_amount.u128(), token_in_denom)];
+                let token_in = coin(in_amount_before_fee.u128(), token_in_denom);
 
+                // if it's exact_out
+                // - fee case: we increase tokens in requirement, it's spreaded through all the tokens in
+                // - incentive case: we credit incentive to the beneficiary
+                let (pool, token_in, _adjustment) =
+                    self.rebalancer_pass(deps.branch(), pool, &mint_to_address, |_, mut pool| {
+                        pool.join_pool(&[token_in.clone()])?;
+                        let std_norm_factor = pool.std_norm_factor()?;
+                        let token_in_norm_factor = pool
+                            .get_pool_asset_by_denom(&token_in_denom)?
+                            .normalization_factor();
+
+                        let rebalancing_adjustment =
+                            move |token_in: Coin, total_adjustment_value: Int256| {
+                                // If adjustment value is negative, fee take from the token_in, so we require addtional token_in to pay for the fee.
+                                // Otherwise, return the token_in as is
+                                let (token_in, adjustment) = match total_adjustment_value
+                                    .cmp(&Int256::zero())
+                                {
+                                    // negative adjustment value means fee deduction from token_in
+                                    Ordering::Less => {
+                                        let fee = convert_amount(
+                                            total_adjustment_value.abs().try_into()?,
+                                            std_norm_factor,
+                                            token_in_norm_factor,
+                                            // rounding up means slightly more fee than required, keeps the incentive pool healthy
+                                            &crate::asset::Rounding::Up,
+                                        )?;
+
+                                        let token_in_amount = token_in.amount.checked_add(fee)?;
+
+                                        (
+                                            coin(token_in_amount.u128(), token_in.denom.clone()),
+                                            Adjustment::DeductFee {
+                                                fee: coin(fee.u128(), token_in.denom.clone()),
+                                            },
+                                        )
+                                    }
+                                    // positive adjustment value means incentive credit to the beneficiary
+                                    Ordering::Greater => (
+                                        token_in,
+                                        Adjustment::CreditIncentive {
+                                            incentive: total_adjustment_value.abs().try_into()?,
+                                        },
+                                    ),
+                                    // zero adjustment means no adjustment
+                                    Ordering::Equal => (token_in, Adjustment::None),
+                                };
+
+                                let token_in_amount = token_in.amount.clone();
+
+                                ensure!(
+                                    token_in_amount <= token_in_max_amount,
+                                    ContractError::ExcessiveRequiredTokenIn {
+                                        limit: token_in_max_amount,
+                                        required: token_in_amount,
+                                    }
+                                );
+
+                                Ok((token_in, adjustment))
+                            };
+                        Ok((pool, token_in, rebalancing_adjustment))
+                    })?;
+
+                // Unlike exact in case where token out is alloyed, there is no separate mint target required here
+                // Because fee is collected from the token_in
                 let response = set_data_if_sudo(
                     response,
                     &entrypoint,
                     &SwapExactAmountOutResponseData {
-                        token_in_amount: in_amount,
+                        token_in_amount: token_in.amount,
                     },
                 )?;
 
-                (tokens_in, token_out_amount, response)
+                (pool, vec![token_in], token_out_amount, response)
             }
         };
 
@@ -130,15 +273,6 @@ impl Transmuter {
             tokens_in.iter().all(|coin| coin.amount > Uint128::zero()),
             ContractError::ZeroValueOperation {}
         );
-
-        (pool, _) =
-            self.rebalancer_pass(deps.branch(), pool, &mint_to_address, |_, mut pool| {
-                pool.join_pool(&tokens_in)?;
-                // TODO: add fee deduction  / incentive credit here
-                Ok((pool, (), |output, total_adjustment_value| {
-                    Ok((output, Adjustment::None))
-                }))
-            })?;
 
         // no need for cleaning up drained corrupted assets here
         // since this function will only adding more underlying assets
@@ -287,6 +421,7 @@ impl Transmuter {
             })
             .collect::<Vec<_>>();
 
+        // TODO: move this logic into rebalancing pass
         let is_force_exit_corrupted_assets = tokens_out.iter().all(|coin| {
             let total_liquidity = pool
                 .get_pool_asset_by_denom(&coin.denom)
@@ -307,7 +442,7 @@ impl Transmuter {
             // TODO: Do we need to handle incentive here still?
             pool.unchecked_exit_pool(&tokens_out)?;
         } else {
-            (pool, _) = self.rebalancer_pass(deps.branch(), pool, &sender, |_, mut pool| {
+            (pool, _, _) = self.rebalancer_pass(deps.branch(), pool, &sender, |_, mut pool| {
                 pool.exit_pool(&tokens_out)?;
                 // TODO: add fee deduction  / incentive credit here
                 Ok((pool, (), |output, total_adjustment_value| {
@@ -351,7 +486,7 @@ impl Transmuter {
     ) -> Result<Response, ContractError> {
         let pool = self.pool.load(deps.storage)?;
 
-        let (mut pool, actual_token_out) =
+        let (mut pool, actual_token_out, _adjustment) =
             self.rebalancer_pass(deps.branch(), pool, &sender, |deps, pool| {
                 let (pool, token_out) =
                     self.out_amt_given_in(deps, pool, token_in, token_out_denom)?;
@@ -439,7 +574,7 @@ impl Transmuter {
     ) -> Result<Response, ContractError> {
         let pool = self.pool.load(deps.storage)?;
 
-        let (mut pool, actual_token_in) =
+        let (mut pool, actual_token_in, _adjustment) =
             self.rebalancer_pass(deps.branch(), pool, &sender, |deps, pool| {
                 let (pool, token_in) = self.in_amt_given_out(
                     deps,
@@ -652,7 +787,7 @@ impl Transmuter {
         pool: TransmuterPool,
         beneficiary: &Addr,
         run_pool: RunPool,
-    ) -> Result<(TransmuterPool, RunPoolOutput), ContractError>
+    ) -> Result<(TransmuterPool, RunPoolOutput, Adjustment), ContractError>
     where
         RunPool:
             FnOnce(
@@ -669,6 +804,7 @@ impl Transmuter {
         // total normalized amount of the asset in the pool
         let total_balance_before = pool.normalized_total_balance()?;
 
+        // **** TODO: separated rebalancing_adjustment into another function to pass in here, instead of this saga-like pattern
         let (pool, output, rebalancing_adjustment) = run_pool(deps.as_ref(), pool)?;
 
         // in case one of token in or out is alloyed, balance_total is updated
@@ -692,13 +828,16 @@ impl Transmuter {
                         let adjustment = compute_total_effective_adjustment_rate(
                             prev_weight,
                             updated_weight,
-                            rebalancing_config,
+                            rebalancing_config.clone(),
                         )?;
+
+                        dbg!(scope, prev_weight, updated_weight, adjustment);
 
                         total_adjustment_rate = total_adjustment_rate.checked_add(adjustment)?;
                     }
                 }
 
+                // TODO: have a way to skip limit check here
                 self.rebalancer
                     .check_limits(deps.storage, scope_value_pairs)?;
             }
@@ -731,15 +870,20 @@ impl Transmuter {
             rebalancing_adjustment(output, round_adjustment(total_adjustment_value)?)?;
 
         match adjustment {
-            Adjustment::DeductFee { fee } => {
+            Adjustment::DeductFee { ref fee } => {
                 self.incentive_pool.add_tokens(deps.storage, &fee)?;
             }
             Adjustment::CreditIncentive { incentive } => {
-                let pool_denom_factors = pool
+                let mut pool_denom_factors = pool
                     .pool_assets
                     .iter()
                     .map(|asset| (asset.denom().to_string(), asset.normalization_factor()))
                     .collect::<BTreeMap<_, _>>();
+
+                let alloyed_denom = self.alloyed_asset.get_alloyed_denom(deps.storage)?;
+                let alloyed_norm_factor =
+                    self.alloyed_asset.get_normalization_factor(deps.storage)?;
+                pool_denom_factors.insert(alloyed_denom, alloyed_norm_factor);
 
                 self.incentive_pool.credit_incentive(
                     deps.storage,
@@ -751,7 +895,7 @@ impl Transmuter {
             Adjustment::None => {}
         }
 
-        Ok((pool, output))
+        Ok((pool, output, adjustment))
     }
 
     pub fn ensure_valid_swap_fee(&self, swap_fee: Decimal) -> Result<(), ContractError> {
@@ -957,9 +1101,10 @@ mod tests {
         testing::{
             mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR,
         },
-        OwnedDeps,
+        CosmosMsg, OwnedDeps,
     };
     use itertools::Itertools;
+    use osmosis_test_tube::cosmrs::proto::prost::Message;
     use rstest::rstest;
     use transmuter_math::rebalancing::config::RebalancingConfig;
 
@@ -2535,5 +2680,297 @@ mod tests {
             .unwrap();
 
         assert_eq!(incentive_pool_balances, vec![]);
+    }
+
+    #[test]
+    fn test_swap_tokens_to_alloyed_asset_exact_in_with_fee_deduction_and_incentivization() {
+        let transmuter = Transmuter::new();
+
+        let (sender, mut deps) = setup_fee_deduction_test();
+
+        // Multiple tokens in that will make denom1 55%, denom2 25%
+        let tokens_in = vec![
+            coin(37_500_000_000u128, "denom1"), // contributes 37_500_000_000 * 100 = 3_750_000_000_000 normalized
+            coin(125_000_000_000u128, "denom2"), // contributes 125_000_000_000 * 10 = 1_250_000_000_000 normalized
+        ];
+
+        // fee(denom1) = 25_000_000_000_000u128 * (5% * 1%) = 12_500_000_000u128
+        // fee(group1) = 25_000_000_000_000u128 * 0% = 0
+        let amount_out_before_fee = Uint128::from(3_750_000_000_000 + 1_250_000_000_000u128);
+        let fee = Uint128::from(125_000_000_000u128);
+        let token_out_amount = amount_out_before_fee - fee;
+
+        let res = transmuter.swap_tokens_to_alloyed_asset(
+            Entrypoint::Exec,
+            SwapToAlloyedConstraint::ExactIn {
+                tokens_in: &tokens_in,
+                token_out_min_amount: token_out_amount + Uint128::from(1u128),
+            },
+            sender.clone(),
+            deps.as_mut(),
+            mock_env(),
+        );
+
+        assert_eq!(
+            res,
+            Err(ContractError::InsufficientTokenOut {
+                min_required: token_out_amount + Uint128::from(1u128),
+                amount_out: token_out_amount,
+            })
+        );
+
+        let res = transmuter.swap_tokens_to_alloyed_asset(
+            Entrypoint::Exec,
+            SwapToAlloyedConstraint::ExactIn {
+                tokens_in: &tokens_in,
+                token_out_min_amount: token_out_amount,
+            },
+            sender.clone(),
+            deps.as_mut(),
+            mock_env(),
+        );
+
+        let messages = res
+            .unwrap()
+            .messages
+            .into_iter()
+            .map(|m| {
+                let CosmosMsg::Stargate { value, .. } = m.msg else {
+                    panic!("must be Startgate message")
+                };
+                MsgMint::decode(value.as_slice()).unwrap()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            messages,
+            vec![
+                MsgMint {
+                    amount: Some(coin(fee.u128(), "alloyed").into()),
+                    mint_to_address: MOCK_CONTRACT_ADDR.to_string(),
+                    sender: MOCK_CONTRACT_ADDR.to_string(),
+                },
+                MsgMint {
+                    amount: Some(coin(token_out_amount.u128(), "alloyed").into()),
+                    mint_to_address: sender.to_string(),
+                    sender: MOCK_CONTRACT_ADDR.to_string(),
+                }
+            ]
+        );
+
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+
+        // Verify pool state after join
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom1").unwrap().amount(),
+            Uint128::from(100_000_000_000u128) + tokens_in[0].amount
+        );
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom2").unwrap().amount(),
+            Uint128::from(500_000_000_000u128) + tokens_in[1].amount
+        );
+
+        // Verify fee is collected (minted to contract)
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+
+        // Fee should be collected in alloyed asset
+        assert_eq!(incentive_pool_balances, vec![coin(fee.u128(), "alloyed")]);
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+        assert_eq!(credits, vec![]);
+
+        // rebalance it back
+
+        let res = transmuter
+            .swap_tokens_to_alloyed_asset(
+                Entrypoint::Exec,
+                SwapToAlloyedConstraint::ExactIn {
+                    tokens_in: &[coin(amount_out_before_fee.u128(), "denom3")],
+                    token_out_min_amount: amount_out_before_fee,
+                },
+                sender.clone(),
+                deps.as_mut(),
+                mock_env(),
+            )
+            .unwrap();
+
+        let messages = res
+            .messages
+            .into_iter()
+            .map(|m| {
+                let CosmosMsg::Stargate { value, .. } = m.msg else {
+                    panic!("must be Startgate message")
+                };
+                MsgMint::decode(value.as_slice()).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            messages,
+            vec![MsgMint {
+                amount: Some(coin(amount_out_before_fee.u128(), "alloyed").into()),
+                mint_to_address: sender.to_string(),
+                sender: MOCK_CONTRACT_ADDR.to_string(),
+            }]
+        );
+
+        // check pool state
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom3").unwrap().amount(),
+            Uint128::from(5_000_000_000_000u128) + amount_out_before_fee
+        );
+
+        // check incentive pool state
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+        assert_eq!(incentive_pool_balances, vec![coin(fee.u128(), "alloyed")]);
+    }
+
+    #[test]
+    fn test_swap_tokens_to_alloyed_asset_exact_out_with_fee_deduction_and_incentivization() {
+        let transmuter = Transmuter::new();
+
+        let (sender, mut deps) = setup_fee_deduction_test();
+
+        // fee(denom1) = 25_000_000_000_000u128 * ((5% * 1%) + (5% * 2%)) = 37_500_000_000
+        // fee(group1) = 25_000_000_000_000u128 * (5% * 1%) = 12_500_000_000
+        // = 50_000_000_000u128
+        let res = transmuter.swap_tokens_to_alloyed_asset(
+            Entrypoint::Exec,
+            SwapToAlloyedConstraint::ExactOut {
+                token_in_denom: "denom1",
+                token_in_max_amount: Uint128::from(55_000_000_000u128 - 1),
+                token_out_amount: Uint128::from(5_000_000_000_000u128),
+            },
+            sender.clone(),
+            deps.as_mut(),
+            mock_env(),
+        );
+
+        assert_eq!(
+            res,
+            Err(ContractError::ExcessiveRequiredTokenIn {
+                limit: Uint128::from(55_000_000_000u128 - 1),
+                required: Uint128::from(55_000_000_000u128),
+            })
+        );
+
+        let token_out_amount = Uint128::from(5_000_000_000_000u128);
+        let amount_in_before_fee = Uint128::from(50_000_000_000u128); // 5_000_000_000_000 / 100
+        let fee = Uint128::from(5_000_000_000u128); // 50_000_000_000 based on the fee calculation
+        let token_in_amount = amount_in_before_fee + fee;
+
+        let res = transmuter.swap_tokens_to_alloyed_asset(
+            Entrypoint::Exec,
+            SwapToAlloyedConstraint::ExactOut {
+                token_in_denom: "denom1",
+                token_in_max_amount: token_in_amount,
+                token_out_amount,
+            },
+            sender.clone(),
+            deps.as_mut(),
+            mock_env(),
+        );
+
+        let messages = res
+            .unwrap()
+            .messages
+            .into_iter()
+            .map(|m| {
+                let CosmosMsg::Stargate { value, .. } = m.msg else {
+                    panic!("must be Startgate message")
+                };
+                MsgMint::decode(value.as_slice()).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            messages,
+            vec![MsgMint {
+                amount: Some(coin(token_out_amount.u128(), "alloyed").into()),
+                mint_to_address: sender.to_string(),
+                sender: MOCK_CONTRACT_ADDR.to_string(),
+            }]
+        );
+
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+
+        // Verify pool state after join
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom1").unwrap().amount(),
+            Uint128::from(100_000_000_000u128) + amount_in_before_fee
+        );
+
+        // Verify fee is collected
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+
+        // Fee should be collected in denom1
+        assert_eq!(incentive_pool_balances, vec![coin(fee.u128(), "denom1")]);
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+        assert_eq!(credits, vec![]);
+
+        // Rebalance back by refilling the same amount for denom2 (which is group1)
+        let res = transmuter
+            .swap_tokens_to_alloyed_asset(
+                Entrypoint::Exec,
+                SwapToAlloyedConstraint::ExactOut {
+                    token_in_denom: "denom2",
+                    token_in_max_amount: Uint128::from(500_000_000_000u128),
+                    token_out_amount: Uint128::from(5_000_000_000_000u128),
+                },
+                sender.clone(),
+                deps.as_mut(),
+                mock_env(),
+            )
+            .unwrap();
+
+        let messages = res
+            .messages
+            .into_iter()
+            .map(|m| {
+                let CosmosMsg::Stargate { value, .. } = m.msg else {
+                    panic!("must be Startgate message")
+                };
+                MsgMint::decode(value.as_slice()).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            messages,
+            vec![MsgMint {
+                amount: Some(coin(token_out_amount.u128(), "alloyed").into()),
+                mint_to_address: sender.to_string(),
+                sender: MOCK_CONTRACT_ADDR.to_string(),
+            }]
+        );
+
+        // check for pool state
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom2").unwrap().amount(),
+            Uint128::from(500_000_000_000u128 + 500_000_000_000u128)
+        );
+
+        // check for incentive credit
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+        assert_eq!(credits, vec![(sender, Uint128::from(500_000_000_000u128))]);
     }
 }

--- a/contracts/transmuter/src/swap.rs
+++ b/contracts/transmuter/src/swap.rs
@@ -320,7 +320,7 @@ impl Transmuter {
 
         let response = Response::new();
 
-        let (in_amount, tokens_out, response) = match constraint {
+        let (in_amount, tokens_out, adjustment, response) = match constraint {
             SwapFromAlloyedConstraint::ExactIn {
                 token_out_denom,
                 token_out_min_amount,
@@ -338,6 +338,7 @@ impl Transmuter {
 
                 let mut token_out = coin(out_amount.u128(), token_out_denom);
                 let tokens_out = vec![token_out.clone()];
+                let mut adjustment = Adjustment::None;
 
                 let denoms_in_corrupted_asset_group = pool
                     .asset_groups
@@ -351,7 +352,6 @@ impl Transmuter {
                     })
                     .collect::<Vec<_>>();
 
-                // TODO: move this logic into rebalancing pass
                 let is_force_exit_corrupted_assets = tokens_out.iter().all(|coin| {
                     let total_liquidity = pool
                         .get_pool_asset_by_denom(&coin.denom)
@@ -394,6 +394,7 @@ impl Transmuter {
                                             // rounding up means slightly more fee than required, keeps the incentive pool healthy
                                             &crate::asset::Rounding::Up,
                                         )?;
+
                                         let token_out_amount: Uint128 =
                                             token_out.amount.checked_sub(fee_amount)?;
                                         let token_out =
@@ -427,7 +428,7 @@ impl Transmuter {
                             Ok((token_out, adjustment))
                         };
 
-                    (pool, token_out, _) = self.rebalancer_pass(
+                    (pool, token_out, adjustment) = self.rebalancer_pass(
                         deps.branch(),
                         pool,
                         &sender,
@@ -446,7 +447,7 @@ impl Transmuter {
 
                 let tokens_out = vec![token_out];
 
-                (token_in_amount, tokens_out, response)
+                (token_in_amount, tokens_out, adjustment, response)
             }
             SwapFromAlloyedConstraint::ExactOut {
                 tokens_out,
@@ -465,6 +466,7 @@ impl Transmuter {
 
                 let token_in_denom = self.alloyed_asset.get_alloyed_denom(deps.storage)?;
                 let mut token_in = coin(in_amount.u128(), token_in_denom.clone());
+                let mut adjustment = Adjustment::None;
 
                 let denoms_in_corrupted_asset_group = pool
                     .asset_groups
@@ -553,7 +555,7 @@ impl Transmuter {
                             Ok((token_in, adjustment))
                         };
 
-                    (pool, token_in, _) = self.rebalancer_pass(
+                    (pool, token_in, adjustment) = self.rebalancer_pass(
                         deps.branch(),
                         pool,
                         &sender,
@@ -570,7 +572,7 @@ impl Transmuter {
                     },
                 )?;
 
-                (token_in.amount, tokens_out.to_vec(), response)
+                (token_in.amount, tokens_out.to_vec(), adjustment, response)
             }
         };
 
@@ -633,8 +635,17 @@ impl Transmuter {
             amount: tokens_out,
         };
 
+        let burn_amount = match (constraint, adjustment) {
+            // If the constraint is exact out, and the adjustment is deduct fee, it means we deduct fee from in amount, which is alloyed
+            // In that case we keep the fee portion in contract and burn the rest
+            (SwapFromAlloyedConstraint::ExactOut { .. }, Adjustment::DeductFee { fee }) => {
+                in_amount.checked_sub(fee.amount)?
+            }
+            _ => in_amount,
+        };
+
         let alloyed_asset_to_burn = coin(
-            in_amount.u128(),
+            burn_amount.u128(),
             self.alloyed_asset.get_alloyed_denom(deps.storage)?,
         )
         .into();
@@ -1275,7 +1286,7 @@ mod tests {
         testing::{
             mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR,
         },
-        CosmosMsg, OwnedDeps,
+        CosmosMsg, OwnedDeps, SubMsg,
     };
     use itertools::Itertools;
     use osmosis_test_tube::cosmrs::proto::prost::Message;
@@ -2464,7 +2475,7 @@ mod tests {
         let sender = Addr::unchecked("sender");
         let mut deps = cosmwasm_std::testing::mock_dependencies_with_balances(&[(
             sender.to_string().as_str(),
-            &[coin(2000000000000u128, "alloyed")],
+            &[coin(20_000_000_000_000u128, "alloyed")],
         )]);
 
         let transmuter = Transmuter::new();
@@ -3146,6 +3157,388 @@ mod tests {
             .get_all_incentive_credits(&deps.storage, None, None)
             .unwrap();
         assert_eq!(credits, vec![(sender, Uint128::from(500_000_000_000u128))]);
+    }
+
+    #[test]
+    fn test_swap_alloyed_asset_to_tokens_exact_in_with_fee_deduction_and_incentivization() {
+        let transmuter = Transmuter::new();
+
+        let (sender, mut deps) = setup_fee_deduction_test();
+
+        // 2_000_000_000_000 alloyed in -> denom1
+
+        // fee(denom1) = 20_000_000_000_000 * (5% * 1%) = 100_000_000_000
+        // fee(group1) = 20_000_000_000_000 * (5% * 1%) = 100_000_000_000
+        let token_in_amount = Uint128::from(2_000_000_000_000u128);
+        let token_out_amount_before_fee = Uint128::from(20_000_000_000u128);
+        let fee = Uint128::from(222_222_223u128);
+        let token_out_amount = token_out_amount_before_fee - fee;
+
+        let res = transmuter.swap_alloyed_asset_to_tokens(
+            Entrypoint::Exec,
+            SwapFromAlloyedConstraint::ExactIn {
+                token_out_denom: "denom1",
+                token_out_min_amount: token_out_amount + Uint128::from(1u128),
+                token_in_amount,
+            },
+            BurnTarget::SenderAccount {},
+            sender.clone(),
+            deps.as_mut(),
+            mock_env(),
+        );
+
+        assert_eq!(
+            res,
+            Err(ContractError::InsufficientTokenOut {
+                min_required: token_out_amount + Uint128::from(1u128),
+                amount_out: token_out_amount,
+            })
+        );
+
+        let res = transmuter
+            .swap_alloyed_asset_to_tokens(
+                Entrypoint::Exec,
+                SwapFromAlloyedConstraint::ExactIn {
+                    token_out_denom: "denom1",
+                    token_out_min_amount: token_out_amount,
+                    token_in_amount,
+                },
+                BurnTarget::SenderAccount {},
+                sender.clone(),
+                deps.as_mut(),
+                mock_env(),
+            )
+            .unwrap();
+
+        let burn_msg = res
+            .messages
+            .get(0)
+            .cloned()
+            .map(|m| {
+                let CosmosMsg::Stargate { value, .. } = m.msg else {
+                    panic!("must be Startgate message")
+                };
+                MsgBurn::decode(value.as_slice()).unwrap()
+            })
+            .unwrap();
+
+        assert_eq!(
+            burn_msg,
+            MsgBurn {
+                burn_from_address: sender.to_string(),
+                amount: Some(coin(token_in_amount.u128(), "alloyed").into()),
+                sender: MOCK_CONTRACT_ADDR.to_string(),
+            }
+        );
+
+        let send_msg = res.messages.get(1).cloned().unwrap();
+
+        assert_eq!(
+            send_msg,
+            SubMsg::new(BankMsg::Send {
+                to_address: sender.to_string(),
+                amount: vec![coin(token_out_amount.u128(), "denom1")],
+            })
+        );
+
+        assert_eq!(res.messages.len(), 2);
+
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+
+        // Verify pool state after exit
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom1").unwrap().amount(),
+            Uint128::from(100_000_000_000u128) - token_out_amount_before_fee
+        );
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom2").unwrap().amount(),
+            Uint128::from(500_000_000_000u128)
+        );
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom3").unwrap().amount(),
+            Uint128::from(5_000_000_000_000u128)
+        );
+
+        // Verify fee is collected (minted to contract)
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+
+        // Fee should be collected in alloyed asset
+        assert_eq!(incentive_pool_balances, vec![coin(fee.u128(), "denom1")]);
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+        assert_eq!(credits, vec![]);
+
+        // rebalance it back
+
+        let tokens_out = vec![coin(200_000_000_000u128, "denom2")];
+
+        let res = transmuter
+            .swap_alloyed_asset_to_tokens(
+                Entrypoint::Exec,
+                SwapFromAlloyedConstraint::ExactOut {
+                    tokens_out: &tokens_out,
+                    token_in_max_amount: Uint128::from(2_000_000_000_000u128),
+                },
+                BurnTarget::SenderAccount {},
+                sender.clone(),
+                deps.as_mut(),
+                mock_env(),
+            )
+            .unwrap();
+
+        let burn_msg = res
+            .messages
+            .get(0)
+            .cloned()
+            .map(|m| {
+                let CosmosMsg::Stargate { value, .. } = m.msg else {
+                    panic!("must be Startgate message")
+                };
+                MsgBurn::decode(value.as_slice()).unwrap()
+            })
+            .unwrap();
+
+        assert_eq!(
+            burn_msg,
+            MsgBurn {
+                burn_from_address: sender.to_string(),
+                amount: Some(coin(2_000_000_000_000u128, "alloyed").into()),
+                sender: MOCK_CONTRACT_ADDR.to_string(),
+            }
+        );
+
+        let send_msg = res.messages.get(1).cloned().unwrap();
+
+        assert_eq!(
+            send_msg,
+            SubMsg::new(BankMsg::Send {
+                to_address: sender.to_string(),
+                amount: tokens_out.clone(),
+            })
+        );
+
+        assert_eq!(res.messages.len(), 2);
+
+        // check pool state
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom2").unwrap().amount(),
+            Uint128::from(500_000_000_000u128 - 200_000_000_000u128)
+        );
+
+        // check incentive pool state
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+        assert_eq!(incentive_pool_balances, vec![coin(fee.u128(), "denom1")]);
+
+        let incetive_credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+        assert_eq!(
+            incetive_credits,
+            vec![(sender, Uint128::from(19_999_999_999u128))]
+        );
+    }
+
+    #[test]
+    fn test_swap_alloyed_asset_to_tokens_exact_out_with_fee_deduction_and_incentivization() {
+        let transmuter = Transmuter::new();
+
+        let (sender, mut deps) = setup_fee_deduction_test();
+
+        // Multiple tokens out that will make denom1 40%, group1 60%
+        let tokens_out = vec![
+            coin(80_000_000_000u128, "denom1"), // remove 80_000_000_000u128 * 100 = 8_000_000_000_000 normalized
+            coin(300_000_000_000u128, "denom2"), // remove 300_000_000_000u128 * 10 = 3_000_000_000_000 normalized
+            coin(4_000_000_000_000u128, "denom3"), // remove 4_000_000_000_000u128 * 1 = 4_000_000_000_000 normalized
+        ];
+
+        // fee(denom1) = 20_000_000_000_000 * (5% * 1%) = 100_000_000_000
+        // fee(group1) = 20_000_000_000_000 * (5% * 1%) = 100_000_000_000
+        let amount_in_before_fee = Uint128::from(15_000_000_000_000u128);
+        let fee = Uint128::from(200_000_000_000u128);
+        let token_in_amount = amount_in_before_fee + fee;
+
+        let res = transmuter.swap_alloyed_asset_to_tokens(
+            Entrypoint::Exec,
+            SwapFromAlloyedConstraint::ExactOut {
+                tokens_out: &tokens_out,
+                token_in_max_amount: token_in_amount - Uint128::from(1u128),
+            },
+            BurnTarget::SenderAccount {},
+            sender.clone(),
+            deps.as_mut(),
+            mock_env(),
+        );
+
+        assert_eq!(
+            res,
+            Err(ContractError::ExcessiveRequiredTokenIn {
+                limit: token_in_amount - Uint128::from(1u128),
+                required: token_in_amount,
+            })
+        );
+
+        let res = transmuter
+            .swap_alloyed_asset_to_tokens(
+                Entrypoint::Exec,
+                SwapFromAlloyedConstraint::ExactOut {
+                    tokens_out: &tokens_out,
+                    token_in_max_amount: token_in_amount,
+                },
+                BurnTarget::SenderAccount {},
+                sender.clone(),
+                deps.as_mut(),
+                mock_env(),
+            )
+            .unwrap();
+
+        let burn_msg = res
+            .messages
+            .get(0)
+            .cloned()
+            .map(|m| {
+                let CosmosMsg::Stargate { value, .. } = m.msg else {
+                    panic!("must be Startgate message")
+                };
+                MsgBurn::decode(value.as_slice()).unwrap()
+            })
+            .unwrap();
+
+        assert_eq!(
+            burn_msg,
+            MsgBurn {
+                burn_from_address: sender.to_string(),
+                amount: Some(coin(amount_in_before_fee.u128(), "alloyed").into()),
+                sender: MOCK_CONTRACT_ADDR.to_string(),
+            }
+        );
+
+        let send_msg = res.messages.get(1).cloned().unwrap();
+
+        assert_eq!(
+            send_msg,
+            SubMsg::new(BankMsg::Send {
+                to_address: sender.to_string(),
+                amount: tokens_out.clone(),
+            })
+        );
+
+        assert_eq!(res.messages.len(), 2);
+
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+
+        // Verify pool state after exit
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom1").unwrap().amount(),
+            Uint128::from(100_000_000_000u128) - tokens_out[0].amount
+        );
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom2").unwrap().amount(),
+            Uint128::from(500_000_000_000u128) - tokens_out[1].amount
+        );
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom3").unwrap().amount(),
+            Uint128::from(5_000_000_000_000u128) - tokens_out[2].amount
+        );
+
+        // Verify fee is collected (minted to contract)
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+
+        // Fee should be collected in alloyed asset
+        assert_eq!(incentive_pool_balances, vec![coin(fee.u128(), "alloyed")]);
+
+        let credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+        assert_eq!(credits, vec![]);
+
+        // rebalance it back
+
+        let tokens_out = vec![coin(100_000_000_000u128, "denom2")];
+
+        let res = transmuter
+            .swap_alloyed_asset_to_tokens(
+                Entrypoint::Exec,
+                SwapFromAlloyedConstraint::ExactOut {
+                    tokens_out: &tokens_out,
+                    token_in_max_amount: Uint128::from(1_000_000_000_000u128),
+                },
+                BurnTarget::SenderAccount {},
+                sender.clone(),
+                deps.as_mut(),
+                mock_env(),
+            )
+            .unwrap();
+
+        let burn_msg = res
+            .messages
+            .get(0)
+            .cloned()
+            .map(|m| {
+                let CosmosMsg::Stargate { value, .. } = m.msg else {
+                    panic!("must be Startgate message")
+                };
+                MsgBurn::decode(value.as_slice()).unwrap()
+            })
+            .unwrap();
+
+        assert_eq!(
+            burn_msg,
+            MsgBurn {
+                burn_from_address: sender.to_string(),
+                amount: Some(coin(1_000_000_000_000u128, "alloyed").into()),
+                sender: MOCK_CONTRACT_ADDR.to_string(),
+            }
+        );
+
+        let send_msg = res.messages.get(1).cloned().unwrap();
+
+        assert_eq!(
+            send_msg,
+            SubMsg::new(BankMsg::Send {
+                to_address: sender.to_string(),
+                amount: tokens_out.clone(),
+            })
+        );
+
+        assert_eq!(res.messages.len(), 2);
+
+        // check pool state
+        let pool = transmuter.pool.load(&deps.storage).unwrap();
+        assert_eq!(
+            pool.get_pool_asset_by_denom("denom3").unwrap().amount(),
+            Uint128::from(1_000_000_000_000u128)
+        );
+
+        // check incentive pool state
+        let incentive_pool_balances = transmuter
+            .incentive_pool
+            .get_all_pool_balances(&deps.storage)
+            .unwrap();
+        assert_eq!(incentive_pool_balances, vec![coin(fee.u128(), "alloyed")]);
+
+        let incetive_credits = transmuter
+            .incentive_pool
+            .get_all_incentive_credits(&deps.storage, None, None)
+            .unwrap();
+        assert_eq!(
+            incetive_credits,
+            vec![(sender, Uint128::from(50_000_000_000u128))]
+        );
     }
 }
 

--- a/contracts/transmuter/src/swap.rs
+++ b/contracts/transmuter/src/swap.rs
@@ -666,16 +666,13 @@ impl Transmuter {
         let prev_asset_weights = pool.asset_weights()?.unwrap_or_default();
         let prev_asset_group_weights = pool.asset_group_weights()?.unwrap_or_default();
 
-        // TODO: return also a fee deduction function that takes output as input
-        // with that we can delegate responsibility to the caller to select to which token to deduct fee from, embeded that in the closure
-        // output is token_out for exact_in, token_in for exact_out
+        // total normalized amount of the asset in the pool
+        let total_balance_before = pool.normalized_total_balance()?;
+
         let (pool, output, rebalancing_adjustment) = run_pool(deps.as_ref(), pool)?;
 
-        // balance_total is the total normalized amount of the asset in the pool
-        let balance_total = pool
-            .normalized_asset_values(pool.std_norm_factor()?)?
-            .into_iter()
-            .try_fold(Uint128::zero(), |acc, (_, value)| acc.checked_add(value))?;
+        // in case one of token in or out is alloyed, balance_total is updated
+        let total_balance_after = pool.normalized_total_balance()?;
 
         // check limits only if pool assets are not zero, calculate adjustment value
         let mut total_adjustment_rate = SignedDecimal256::zero();
@@ -707,9 +704,28 @@ impl Transmuter {
             }
         }
 
-        let total_adjustment_value = total_adjustment_rate.checked_mul(
-            SignedDecimal256::from_atomics(Int256::from(balance_total), 0)?,
-        )?;
+        // if total balance is updated, it means that one of token in or out is alloyed
+        let total_balance = if total_balance_before != total_balance_after {
+            match total_adjustment_rate.cmp(&SignedDecimal256::zero()) {
+                // Incentivized case:
+                // Incentives are paid from a pool of previously collected fees. It is logical to scale the reward based on the state of the pool *before* the user's helpful contribution.
+                // This provides a fair reward relative to the pool's history and prevents a single large, helpful deposit from draining a disproportionate amount of the incentive fund.
+                Ordering::Greater => total_balance_before,
+                // Fee deduction case:
+                // This keeps the incentive pool healthy by ensuring that the incentive is proportional to the pool's size.
+                // - For **harmful joins** (liquidity addition), the fee is based on `total_balance_after`. This ensures the penalty is proportional to the new, larger pool size that the user has unbalanced.
+                // - For **harmful exits** (liquidity withdrawal), the fee is based on `total_balance_before`. This ensures the penalty is proportional to the state of the pool *before* it was damaged by the withdrawal.
+                Ordering::Less => total_balance_before.max(total_balance_after),
+
+                // No adjustment, so this doesn't matter
+                Ordering::Equal => Uint128::zero(),
+            }
+        } else {
+            total_balance_before
+        };
+
+        let total_balance = SignedDecimal256::from_atomics(Int256::from(total_balance), 0)?;
+        let total_adjustment_value = total_adjustment_rate.checked_mul(total_balance)?;
 
         let (output, adjustment) =
             rebalancing_adjustment(output, round_adjustment(total_adjustment_value)?)?;

--- a/contracts/transmuter/src/test/cases/scenarios.rs
+++ b/contracts/transmuter/src/test/cases/scenarios.rs
@@ -17,7 +17,7 @@ use crate::{
 use cosmwasm_std::{coin, Decimal, Uint128};
 
 use osmosis_std::types::{
-    cosmos::bank::v1beta1::MsgSend,
+    cosmos::bank::v1beta1::{MsgSend, QueryBalanceRequest},
     osmosis::poolmanager::v1beta1::{
         EstimateSwapExactAmountInRequest, EstimateSwapExactAmountInResponse, MsgSwapExactAmountIn,
         MsgSwapExactAmountOut, SwapAmountInRoute, SwapAmountOutRoute,
@@ -472,6 +472,10 @@ fn test_exit_pool() {
             "provider",
             vec![coin(100_000, AXL_USDC), coin(100_000, COSMOS_USDC)],
         )
+        .with_account(
+            "another_provider",
+            vec![coin(100_000, AXL_USDC), coin(100_000, COSMOS_USDC)],
+        )
         .with_account("user", vec![coin(1_000, AXL_USDC)])
         .with_instantiate_msg(InstantiateMsg {
             pool_asset_configs: vec![
@@ -486,6 +490,14 @@ fn test_exit_pool() {
         .build(&app);
 
     // Join pool with 50:50 ratio
+    t.contract
+        .execute(
+            &ExecMsg::JoinPool {},
+            &[coin(50_000, AXL_USDC), coin(50_000, COSMOS_USDC)],
+            &t.accounts["another_provider"],
+        )
+        .unwrap();
+
     t.contract
         .execute(
             &ExecMsg::JoinPool {},
@@ -585,6 +597,28 @@ fn test_exit_pool() {
         },
         err,
     );
+
+    let GetShareDenomResponse { share_denom } =
+        t.contract.query(&QueryMsg::GetShareDenom {}).unwrap();
+
+    let bank = Bank::new(&app);
+    let another_provider_share = bank
+        .query_balance(&QueryBalanceRequest {
+            address: t.accounts["another_provider"].address(),
+            denom: share_denom,
+        })
+        .unwrap()
+        .balance
+        .unwrap();
+    bank.send(
+        MsgSend {
+            from_address: t.accounts["another_provider"].address(),
+            to_address: t.accounts["provider"].address(),
+            amount: vec![another_provider_share],
+        },
+        &t.accounts["another_provider"],
+    )
+    .unwrap();
 
     // Exit remaining tokens in the pool
     let GetTotalPoolLiquidityResponse {

--- a/contracts/transmuter/src/test/cases/units/join_and_exit.rs
+++ b/contracts/transmuter/src/test/cases/units/join_and_exit.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, u128};
 
 use cosmwasm_std::{attr, coin, Coin, Uint128};
 use itertools::Itertools;
@@ -517,23 +517,23 @@ fn test_exit_pool_greater_than_their_shares_should_fail() {
             exit: vec![coin(100_000_001, "denoma")],
         },
         Case {
-            join: vec![coin(u128::MAX - 1, "denoma")],
-            exit: vec![coin(u128::MAX, "denoma")],
-        },
-        Case {
-            join: vec![
-                coin(u128::MAX - 100_000_000, "denoma"),
-                coin(99_999_999, "denomb"),
-            ],
-            exit: vec![coin(u128::MAX, "denoma")],
+            join: vec![coin(u128::MAX - 3, "denoma")],
+            exit: vec![coin(u128::MAX - 2, "denoma")],
         },
     ];
 
     for case in cases {
         let app = OsmosisTestApp::new();
 
+        let base_liquidity = vec![coin(1, "denoma"), coin(1, "denomb")];
+
         // create denom
-        app.init_account(&[coin(1, "denoma"), coin(1, "denomb")])
+        let someone = app
+            .init_account(&[
+                coin(1, "denoma"),
+                coin(1, "denomb"),
+                coin(20000000000000, "uosmo"),
+            ])
             .unwrap();
 
         let t = TestEnvBuilder::new()
@@ -549,6 +549,10 @@ fn test_exit_pool_greater_than_their_shares_should_fail() {
                 moderator: "osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks".to_string(),
             })
             .build(&app);
+
+        t.contract
+            .execute(&ExecMsg::JoinPool {}, &base_liquidity, &someone)
+            .unwrap();
 
         t.contract
             .execute(&ExecMsg::JoinPool {}, &case.join, &t.accounts["addr"])

--- a/contracts/transmuter/src/test/cases/units/swap/mod.rs
+++ b/contracts/transmuter/src/test/cases/units/swap/mod.rs
@@ -532,5 +532,6 @@ fn pool_with_single_lp(
 mod client_error;
 mod non_empty_pool;
 mod swap_share_denom;
+mod swap_with_fee_deduction;
 
 mod swap_with_asset_group_limiters;

--- a/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
+++ b/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
@@ -12,7 +12,7 @@ use crate::test::{modules::cosmwasm_pool::CosmwasmPool, test_env::TestEnv};
 use crate::{
     asset::AssetConfig,
     contract::sv::{ExecMsg, QueryMsg},
-    contract::GetTotalPoolLiquidityResponse,
+    contract::{GetIncentivePoolBalancesResponse, GetTotalPoolLiquidityResponse},
     scope::Scope,
     test::test_env::TestEnvBuilder,
 };
@@ -243,6 +243,21 @@ fn verify_contract_balances(
         .contract
         .query(&QueryMsg::GetTotalPoolLiquidity {})
         .unwrap();
+
+    // Query the incentive pool balances from the contract
+    let incentive_pool_balances: GetIncentivePoolBalancesResponse = t
+        .contract
+        .query(&QueryMsg::GetIncentivePoolBalances {})
+        .unwrap();
+
+    // Verify the incentive pool balances
+    for balance in incentive_pool_balances.balances {
+        if balance.denom == fee_denom {
+            assert_eq!(balance.amount, expected_fee_amount);
+        } else {
+            assert_eq!(balance.amount, Uint128::zero());
+        }
+    }
 
     // For each denom in the pool, verify contract balance
     for pool_coin in &pool_liquidity.total_pool_liquidity {

--- a/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
+++ b/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
@@ -1,0 +1,275 @@
+use cosmwasm_std::{coin, Decimal, Uint128};
+use osmosis_std::types::{
+    cosmos::bank::v1beta1::QueryBalanceRequest,
+    osmosis::poolmanager::v1beta1::{
+        MsgSwapExactAmountIn, MsgSwapExactAmountOut, SwapAmountInRoute, SwapAmountOutRoute,
+    },
+};
+use osmosis_test_tube::{Account, Bank, Module, OsmosisTestApp};
+use transmuter_math::rebalancing::config::RebalancingConfig;
+
+use crate::test::{modules::cosmwasm_pool::CosmwasmPool, test_env::TestEnv};
+use crate::{
+    asset::AssetConfig,
+    contract::sv::{ExecMsg, QueryMsg},
+    contract::GetTotalPoolLiquidityResponse,
+    scope::Scope,
+    test::test_env::TestEnvBuilder,
+};
+
+const DENOM1_INITIAL: u128 = 100_000_000_000;
+const DENOM2_INITIAL: u128 = 500_000_000_000;
+const DENOM3_INITIAL: u128 = 5_000_000_000_000;
+
+#[test]
+fn test_swap_exact_amount_out_with_fee_deduction() {
+    let app = OsmosisTestApp::new();
+    let t = setup_test_env(&app);
+    let cp = CosmwasmPool::new(&app);
+
+    // Test the swap that should require fee
+    // This swap makes denom1 weight go from 50% to 60%, triggering fee
+    let token_out = coin(200_000_000_000u128, "denom2");
+    let amount_in_before_fee = Uint128::from(20_000_000_000u128);
+    let expected_fee = Uint128::from(1_000_000_000u128) + Uint128::from(3_000_000_000u128); // group1 + denom1 fees
+    let token_in_amount = amount_in_before_fee + expected_fee;
+
+    // Test with insufficient max amount (should fail)
+    let insufficient_max = token_in_amount - Uint128::from(1u128);
+    let err = cp
+        .swap_exact_amount_out(
+            MsgSwapExactAmountOut {
+                sender: t.accounts["swapper"].address(),
+                routes: vec![SwapAmountOutRoute {
+                    pool_id: t.contract.pool_id,
+                    token_in_denom: "denom1".to_string(),
+                }],
+                token_out: Some(token_out.clone().into()),
+                token_in_max_amount: insufficient_max.to_string(),
+            },
+            &t.accounts["swapper"],
+        )
+        .unwrap_err();
+
+    // Should fail due to excessive token in required
+    assert!(err.to_string().contains("Excessive token in required"));
+
+    // Test with sufficient max amount (should succeed)
+    cp.swap_exact_amount_out(
+        MsgSwapExactAmountOut {
+            sender: t.accounts["swapper"].address(),
+            routes: vec![SwapAmountOutRoute {
+                pool_id: t.contract.pool_id,
+                token_in_denom: "denom1".to_string(),
+            }],
+            token_out: Some(token_out.into()),
+            token_in_max_amount: token_in_amount.to_string(),
+        },
+        &t.accounts["swapper"],
+    )
+    .unwrap();
+
+    // Verify contract balances include pool liquidity + collected fees
+    verify_contract_balances(&t, expected_fee, "denom1");
+}
+
+#[test]
+fn test_swap_exact_amount_in_with_fee_deduction() {
+    let app = OsmosisTestApp::new();
+    let cp = CosmwasmPool::new(&app);
+
+    let t = setup_test_env(&app);
+
+    // Test the swap that should require fee deduction from output
+    let token_in = coin(20_000_000_000u128, "denom1");
+    let amount_out_before_fee = Uint128::from(200_000_000_000u128);
+    let expected_fee = Uint128::from(10_000_000_000u128) + Uint128::from(30_000_000_000u128); // group1 + denom1 fees
+    let token_out_amount = amount_out_before_fee - expected_fee;
+
+    // Test with min amount too high (should fail)
+    let excessive_min = token_out_amount + Uint128::from(1u128);
+    let err = cp
+        .swap_exact_amount_in(
+            MsgSwapExactAmountIn {
+                sender: t.accounts["swapper"].address(),
+                routes: vec![SwapAmountInRoute {
+                    pool_id: t.contract.pool_id,
+                    token_out_denom: "denom2".to_string(),
+                }],
+                token_in: Some(token_in.clone().into()),
+                token_out_min_amount: excessive_min.to_string(),
+            },
+            &t.accounts["swapper"],
+        )
+        .unwrap_err();
+
+    // Should fail due to insufficient token out
+    assert!(err.to_string().contains("Insufficient token out"));
+
+    // Test with appropriate min amount (should succeed)
+    cp.swap_exact_amount_in(
+        MsgSwapExactAmountIn {
+            sender: t.accounts["swapper"].address(),
+            routes: vec![SwapAmountInRoute {
+                pool_id: t.contract.pool_id,
+                token_out_denom: "denom2".to_string(),
+            }],
+            token_in: Some(token_in.into()),
+            token_out_min_amount: token_out_amount.to_string(),
+        },
+        &t.accounts["swapper"],
+    )
+    .unwrap();
+
+    // Verify contract balances include pool liquidity + collected fees
+    verify_contract_balances(&t, expected_fee, "denom2");
+}
+
+fn setup_test_env<'a>(app: &'a OsmosisTestApp) -> TestEnv<'a> {
+    let admin = app.init_account(&[coin(100_000u128, "uosmo")]).unwrap();
+
+    let t = TestEnvBuilder::new()
+        .with_account("admin", vec![])
+        .with_account("swapper", vec![coin(1_000_000_000_000, "denom1")])
+        .with_account(
+            "provider",
+            vec![
+                coin(DENOM1_INITIAL, "denom1"),
+                coin(DENOM2_INITIAL, "denom2"),
+                coin(DENOM3_INITIAL, "denom3"),
+            ],
+        )
+        .with_instantiate_msg(crate::contract::sv::InstantiateMsg {
+            pool_asset_configs: vec![
+                AssetConfig {
+                    denom: "denom1".to_string(),
+                    normalization_factor: Uint128::one(),
+                },
+                AssetConfig {
+                    denom: "denom2".to_string(),
+                    normalization_factor: Uint128::new(10),
+                },
+                AssetConfig {
+                    denom: "denom3".to_string(),
+                    normalization_factor: Uint128::new(100),
+                },
+            ],
+            alloyed_asset_subdenom: "usd".to_string(),
+            alloyed_asset_normalization_factor: Uint128::new(100),
+            admin: Some(admin.address()),
+            moderator: "osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks".to_string(),
+        })
+        .build(&app);
+
+    // Add initial liquidity to the pool
+    t.contract
+        .execute(
+            &ExecMsg::JoinPool {},
+            &[
+                coin(DENOM1_INITIAL, "denom1"),
+                coin(DENOM2_INITIAL, "denom2"),
+                coin(DENOM3_INITIAL, "denom3"),
+            ],
+            &t.accounts["provider"],
+        )
+        .unwrap();
+
+    // Create asset group for denom2 and denom3
+    t.contract
+        .execute(
+            &ExecMsg::CreateAssetGroup {
+                label: "group1".to_string(),
+                denoms: vec!["denom2".to_string(), "denom3".to_string()],
+            },
+            &[],
+            &t.accounts["admin"],
+        )
+        .unwrap();
+
+    // Add rebalancing config for denom1 (same as unit test)
+    t.contract
+        .execute(
+            &ExecMsg::AddRebalancingConfig {
+                scope: Scope::denom("denom1"),
+                rebalancing_config: RebalancingConfig::new(
+                    Decimal::percent(50),
+                    Decimal::percent(45),
+                    Decimal::percent(55),
+                    Decimal::percent(30),
+                    Decimal::percent(65),
+                    Decimal::percent(10),
+                    Decimal::percent(20),
+                )
+                .unwrap(),
+            },
+            &[],
+            &t.accounts["admin"],
+        )
+        .unwrap();
+
+    t.contract
+        .execute(
+            &ExecMsg::AddRebalancingConfig {
+                scope: Scope::asset_group("group1"),
+                rebalancing_config: RebalancingConfig::new(
+                    Decimal::percent(55),
+                    Decimal::percent(45),
+                    Decimal::percent(60),
+                    Decimal::percent(30),
+                    Decimal::percent(65),
+                    Decimal::percent(10),
+                    Decimal::percent(20),
+                )
+                .unwrap(),
+            },
+            &[],
+            &t.accounts["admin"],
+        )
+        .unwrap();
+
+    t
+}
+
+/// Helper function to verify that contract balances equal pool liquidity plus collected fees
+fn verify_contract_balances(
+    t: &crate::test::test_env::TestEnv,
+    expected_fee_amount: Uint128,
+    fee_denom: &str,
+) {
+    let bank = Bank::new(t.app);
+
+    // Query the pool liquidity from the contract
+    let pool_liquidity: GetTotalPoolLiquidityResponse = t
+        .contract
+        .query(&QueryMsg::GetTotalPoolLiquidity {})
+        .unwrap();
+
+    // For each denom in the pool, verify contract balance
+    for pool_coin in &pool_liquidity.total_pool_liquidity {
+        let contract_balance = bank
+            .query_balance(&QueryBalanceRequest {
+                address: t.contract.contract_addr.to_string(),
+                denom: pool_coin.denom.clone(),
+            })
+            .unwrap()
+            .balance
+            .unwrap();
+
+        let expected_balance = if pool_coin.denom == fee_denom {
+            // For the fee denom, expect pool amount + collected fees
+            pool_coin.amount + expected_fee_amount
+        } else {
+            // For other denoms, expect just the pool amount
+            pool_coin.amount
+        };
+
+        assert_eq!(
+            contract_balance.amount.parse::<u128>().unwrap(),
+            expected_balance.u128(),
+            "Contract balance mismatch for {}: expected {}, got {}",
+            pool_coin.denom,
+            expected_balance,
+            contract_balance.amount
+        );
+    }
+}

--- a/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
+++ b/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{coin, Decimal, Uint128};
 use osmosis_std::types::{
-    cosmos::bank::v1beta1::QueryBalanceRequest,
+    cosmos::bank::v1beta1::{MsgSend, QueryBalanceRequest},
     osmosis::poolmanager::v1beta1::{
         MsgSwapExactAmountIn, MsgSwapExactAmountOut, SwapAmountInRoute, SwapAmountOutRoute,
     },
@@ -283,6 +283,189 @@ fn test_swap_tokens_to_alloyed_asset_exact_out_with_fee_deduction() {
     assert_eq!(
         total_shares,
         initial_total_alloyed_asset_supply + token_out_amount
+    );
+}
+
+#[test]
+fn test_swap_alloyed_asset_to_tokens_exact_in_with_fee_deduction() {
+    let app = OsmosisTestApp::new();
+    let t = setup_test_env(&app);
+    let cp = CosmwasmPool::new(&app);
+    let bank = Bank::new(&app);
+
+    // Query the share denom (alloyed asset denom)
+    let share_denom: String = t
+        .contract
+        .query::<crate::contract::GetShareDenomResponse>(&QueryMsg::GetShareDenom {})
+        .unwrap()
+        .share_denom;
+
+    let initial_total_alloyed_asset_supply = t
+        .contract
+        .query::<GetTotalSharesResponse>(&QueryMsg::GetTotalShares {})
+        .unwrap()
+        .total_shares;
+
+    // 2_000_000_000_000 alloyed in -> denom1
+    let token_in_amount = Uint128::from(2_000_000_000_000u128);
+    let token_out_amount_before_fee = Uint128::from(20_000_000_000u128);
+    let fee = Uint128::from(222_222_223u128);
+    let token_out_amount = token_out_amount_before_fee - fee;
+
+    // send share_denom from provider to swapper with token_in_amount
+    bank.send(
+        MsgSend {
+            from_address: t.accounts["provider"].address().to_string(),
+            to_address: t.accounts["swapper"].address().to_string(),
+            amount: vec![coin(token_in_amount.u128(), &share_denom).into()],
+        },
+        &t.accounts["provider"],
+    )
+    .unwrap();
+
+    // Try with min out too high (should fail)
+    let err = cp
+        .swap_exact_amount_in(
+            MsgSwapExactAmountIn {
+                sender: t.accounts["swapper"].address(),
+                routes: vec![SwapAmountInRoute {
+                    pool_id: t.contract.pool_id,
+                    token_out_denom: "denom1".to_string(),
+                }],
+                token_in: Some(coin(token_in_amount.u128(), &share_denom).into()),
+                token_out_min_amount: (token_out_amount + Uint128::from(1u128)).to_string(),
+            },
+            &t.accounts["swapper"],
+        )
+        .unwrap_err();
+
+    assert!(err.to_string().contains("Insufficient token out"));
+
+    // Try with correct min out (should succeed)
+    cp.swap_exact_amount_in(
+        MsgSwapExactAmountIn {
+            sender: t.accounts["swapper"].address(),
+            routes: vec![SwapAmountInRoute {
+                pool_id: t.contract.pool_id,
+                token_out_denom: "denom1".to_string(),
+            }],
+            token_in: Some(coin(token_in_amount.u128(), &share_denom).into()),
+            token_out_min_amount: token_out_amount.to_string(),
+        },
+        &t.accounts["swapper"],
+    )
+    .unwrap();
+
+    // Check that the swapper has received the correct amount of denom1
+    let balance = bank
+        .query_balance(&QueryBalanceRequest {
+            address: t.accounts["swapper"].address().to_string(),
+            denom: "denom1".to_string(),
+        })
+        .unwrap()
+        .balance
+        .unwrap()
+        .amount
+        .parse::<u128>()
+        .unwrap();
+    assert_eq!(balance, 1_000_000_000_000 + token_out_amount.u128());
+
+    // Check contract balances and incentive pool
+    verify_contract_balances(&t, fee, "denom1");
+
+    let total_shares = t
+        .contract
+        .query::<GetTotalSharesResponse>(&QueryMsg::GetTotalShares {})
+        .unwrap()
+        .total_shares;
+
+    assert_eq!(
+        total_shares,
+        initial_total_alloyed_asset_supply - token_in_amount
+    );
+}
+
+#[test]
+fn test_swap_alloyed_asset_to_tokens_exact_out_with_fee_deduction() {
+    let app = OsmosisTestApp::new();
+    let t = setup_test_env(&app);
+    let bank = Bank::new(&app);
+
+    // Query the share denom (alloyed asset denom)
+    let share_denom: String = t
+        .contract
+        .query::<crate::contract::GetShareDenomResponse>(&QueryMsg::GetShareDenom {})
+        .unwrap()
+        .share_denom;
+
+    let initial_total_alloyed_asset_supply = t
+        .contract
+        .query::<GetTotalSharesResponse>(&QueryMsg::GetTotalShares {})
+        .unwrap()
+        .total_shares;
+
+    // Multiple tokens out that will make denom1 40%, group1 60%
+    let tokens_out = vec![
+        coin(80_000_000_000u128, "denom1"),
+        coin(300_000_000_000u128, "denom2"),
+        coin(4_000_000_000_000u128, "denom3"),
+    ];
+
+    // fee(denom1) = 20_000_000_000_000 * (5% * 1%) = 100_000_000_000
+    // fee(group1) = 20_000_000_000_000 * (5% * 1%) = 100_000_000_000
+    let amount_in_before_fee = Uint128::from(15_000_000_000_000u128);
+    let fee = Uint128::from(200_000_000_000u128);
+    let token_in_amount = amount_in_before_fee + fee;
+
+    // send share_denom from provider to swapper with token_in_amount
+    bank.send(
+        MsgSend {
+            from_address: t.accounts["provider"].address().to_string(),
+            to_address: t.accounts["swapper"].address().to_string(),
+            amount: vec![coin(token_in_amount.u128(), &share_denom).into()],
+        },
+        &t.accounts["provider"],
+    )
+    .unwrap();
+
+    t.contract
+        .execute(
+            &ExecMsg::ExitPool {
+                tokens_out: tokens_out.clone(),
+            },
+            &[],
+            &t.accounts["swapper"],
+        )
+        .unwrap();
+
+    // Check that the swapper has received the correct amounts of tokens out
+    for coin_out in &tokens_out {
+        let balance = bank
+            .query_balance(&QueryBalanceRequest {
+                address: t.accounts["swapper"].address().to_string(),
+                denom: coin_out.denom.clone(),
+            })
+            .unwrap()
+            .balance
+            .unwrap()
+            .amount
+            .parse::<u128>()
+            .unwrap();
+        assert_eq!(balance, 1_000_000_000_000 + coin_out.amount.u128());
+    }
+
+    // Check contract balances and incentive pool
+    verify_contract_balances(&t, fee, &share_denom);
+
+    let total_shares = t
+        .contract
+        .query::<GetTotalSharesResponse>(&QueryMsg::GetTotalShares {})
+        .unwrap()
+        .total_shares;
+
+    assert_eq!(
+        total_shares,
+        initial_total_alloyed_asset_supply - amount_in_before_fee
     );
 }
 

--- a/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
+++ b/contracts/transmuter/src/test/cases/units/swap/swap_with_fee_deduction.rs
@@ -8,13 +8,16 @@ use osmosis_std::types::{
 use osmosis_test_tube::{Account, Bank, Module, OsmosisTestApp};
 use transmuter_math::rebalancing::config::RebalancingConfig;
 
-use crate::test::{modules::cosmwasm_pool::CosmwasmPool, test_env::TestEnv};
 use crate::{
     asset::AssetConfig,
     contract::sv::{ExecMsg, QueryMsg},
     contract::{GetIncentivePoolBalancesResponse, GetTotalPoolLiquidityResponse},
     scope::Scope,
     test::test_env::TestEnvBuilder,
+};
+use crate::{
+    contract::GetTotalSharesResponse,
+    test::{modules::cosmwasm_pool::CosmwasmPool, test_env::TestEnv},
 };
 
 const DENOM1_INITIAL: u128 = 100_000_000_000;
@@ -125,12 +128,177 @@ fn test_swap_exact_amount_in_with_fee_deduction() {
     verify_contract_balances(&t, expected_fee, "denom2");
 }
 
+#[test]
+fn test_swap_tokens_to_alloyed_asset_exact_in_with_fee_deduction() {
+    let app = OsmosisTestApp::new();
+    let t = setup_test_env(&app);
+
+    let bank = Bank::new(&app);
+
+    let initial_total_alloyed_asset_supply = t
+        .contract
+        .query::<GetTotalSharesResponse>(&QueryMsg::GetTotalShares {})
+        .unwrap()
+        .total_shares;
+
+    // Query the share denom (alloyed asset denom)
+    let share_denom: String = t
+        .contract
+        .query::<crate::contract::GetShareDenomResponse>(&QueryMsg::GetShareDenom {})
+        .unwrap()
+        .share_denom;
+
+    // Multiple tokens in that will make denom1 55%, denom2 25%
+    let tokens_in = vec![
+        coin(37_500_000_000u128, "denom1"), // 3_750_000_000_000 normalized
+        coin(125_000_000_000u128, "denom2"), // 1_250_000_000_000 normalized
+    ];
+
+    // fee(denom1) = 25_000_000_000_000u128 * (5% * 1%) = 12_500_000_000u128
+    // fee(group1) = 25_000_000_000_000u128 * 0% = 0
+    let amount_out_before_fee = Uint128::from(3_750_000_000_000u128 + 1_250_000_000_000u128);
+    let fee = Uint128::from(125_000_000_000u128);
+    let token_out_amount = amount_out_before_fee - fee;
+
+    // Try with correct min out (should succeed)
+    t.contract
+        .execute(&ExecMsg::JoinPool {}, &tokens_in, &t.accounts["swapper"])
+        .unwrap();
+
+    // The contract should have minted the correct fee and output
+    verify_contract_balances(&t, fee, &share_denom);
+
+    // Check that the swapper has received the correct amount of the share denom
+    let balance = bank
+        .query_balance(&QueryBalanceRequest {
+            address: t.accounts["swapper"].address().to_string(),
+            denom: share_denom.clone(),
+        })
+        .unwrap()
+        .balance
+        .unwrap()
+        .amount
+        .parse::<u128>()
+        .unwrap();
+    assert_eq!(balance, token_out_amount.u128());
+
+    // Check for total alloyed asset total supply
+    let total_shares = t
+        .contract
+        .query::<GetTotalSharesResponse>(&QueryMsg::GetTotalShares {})
+        .unwrap()
+        .total_shares;
+
+    assert_eq!(
+        total_shares,
+        initial_total_alloyed_asset_supply + amount_out_before_fee
+    );
+}
+
+#[test]
+fn test_swap_tokens_to_alloyed_asset_exact_out_with_fee_deduction() {
+    let app = OsmosisTestApp::new();
+    let t = setup_test_env(&app);
+    let cp = CosmwasmPool::new(&app);
+    let bank = Bank::new(&app);
+
+    let initial_total_alloyed_asset_supply = t
+        .contract
+        .query::<GetTotalSharesResponse>(&QueryMsg::GetTotalShares {})
+        .unwrap()
+        .total_shares;
+
+    // Query the share denom (alloyed asset denom)
+    let share_denom: String = t
+        .contract
+        .query::<crate::contract::GetShareDenomResponse>(&QueryMsg::GetShareDenom {})
+        .unwrap()
+        .share_denom;
+
+    // fee(denom1) = 25_000_000_000_000u128 * ((5% * 1%) + (5% * 2%)) = 37_500_000_000
+    // fee(group1) = 25_000_000_000_000u128 * (5% * 1%) = 12_500_000_000
+    // = 50_000_000_000u128
+    let token_out_amount = Uint128::from(5_000_000_000_000u128);
+    let amount_in_before_fee = Uint128::from(50_000_000_000u128); // 5_000_000_000_000 / 100
+    let fee = Uint128::from(5_000_000_000u128); // 50_000_000_000 based on the fee calculation
+    let token_in_amount = amount_in_before_fee + fee;
+
+    // Try with max in too low (should fail)
+    let err = cp
+        .swap_exact_amount_out(
+            MsgSwapExactAmountOut {
+                sender: t.accounts["swapper"].address(),
+                routes: vec![SwapAmountOutRoute {
+                    pool_id: t.contract.pool_id,
+                    token_in_denom: "denom1".to_string(),
+                }],
+                token_out: Some(coin(token_out_amount.u128(), &share_denom).into()),
+                token_in_max_amount: (token_in_amount - Uint128::from(1u128)).to_string(),
+            },
+            &t.accounts["swapper"],
+        )
+        .unwrap_err();
+    assert!(err.to_string().contains("Excessive token in required"));
+
+    // Try with correct max in (should succeed)
+    cp.swap_exact_amount_out(
+        MsgSwapExactAmountOut {
+            sender: t.accounts["swapper"].address(),
+            routes: vec![SwapAmountOutRoute {
+                pool_id: t.contract.pool_id,
+                token_in_denom: "denom1".to_string(),
+            }],
+            token_out: Some(coin(token_out_amount.u128(), &share_denom).into()),
+            token_in_max_amount: token_in_amount.to_string(),
+        },
+        &t.accounts["swapper"],
+    )
+    .unwrap();
+
+    // The contract should have minted the correct fee and output
+    verify_contract_balances(&t, fee, "denom1");
+
+    // Check that the swapper has received the correct amount of the share denom
+    let balance = bank
+        .query_balance(&QueryBalanceRequest {
+            address: t.accounts["swapper"].address().to_string(),
+            denom: share_denom.clone(),
+        })
+        .unwrap()
+        .balance
+        .unwrap()
+        .amount
+        .parse::<u128>()
+        .unwrap();
+    assert_eq!(balance, token_out_amount.u128());
+
+    // Check for total alloyed asset total supply
+    let total_shares = t
+        .contract
+        .query::<crate::contract::GetTotalSharesResponse>(&QueryMsg::GetTotalShares {})
+        .unwrap()
+        .total_shares;
+
+    // The total supply should have increased by the output amount
+    assert_eq!(
+        total_shares,
+        initial_total_alloyed_asset_supply + token_out_amount
+    );
+}
+
 fn setup_test_env<'a>(app: &'a OsmosisTestApp) -> TestEnv<'a> {
     let admin = app.init_account(&[coin(100_000u128, "uosmo")]).unwrap();
 
     let t = TestEnvBuilder::new()
         .with_account("admin", vec![])
-        .with_account("swapper", vec![coin(1_000_000_000_000, "denom1")])
+        .with_account(
+            "swapper",
+            vec![
+                coin(1_000_000_000_000, "denom1"),
+                coin(1_000_000_000_000, "denom2"),
+                coin(1_000_000_000_000, "denom3"),
+            ],
+        )
         .with_account(
             "provider",
             vec![

--- a/contracts/transmuter/src/transmuter_pool/weight.rs
+++ b/contracts/transmuter/src/transmuter_pool/weight.rs
@@ -21,11 +21,7 @@ impl TransmuterPool {
     /// If total pool asset amount is zero, returns None to signify that
     /// it makes no sense to calculate ratios, but not an error.
     pub fn asset_weights(&self) -> Result<Option<BTreeMap<String, Decimal>>, ContractError> {
-        let std_norm_factor = lcm_from_iter(
-            self.pool_assets
-                .iter()
-                .map(|pool_asset| pool_asset.normalization_factor()),
-        )?;
+        let std_norm_factor = self.std_norm_factor()?;
 
         let normalized_asset_values = self.normalized_asset_values(std_norm_factor)?;
 
@@ -49,6 +45,14 @@ impl TransmuterPool {
             .collect::<Result<_, ContractError>>()?;
 
         Ok(Some(ratios))
+    }
+
+    pub fn std_norm_factor(&self) -> Result<Uint128, ContractError> {
+        Ok(lcm_from_iter(
+            self.pool_assets
+                .iter()
+                .map(|pool_asset| pool_asset.normalization_factor()),
+        )?)
     }
 
     pub(crate) fn normalized_asset_values(

--- a/contracts/transmuter/src/transmuter_pool/weight.rs
+++ b/contracts/transmuter/src/transmuter_pool/weight.rs
@@ -73,6 +73,13 @@ impl TransmuterPool {
             })
             .collect()
     }
+
+    pub(crate) fn normalized_total_balance(&self) -> Result<Uint128, ContractError> {
+        self.normalized_asset_values(self.std_norm_factor()?)?
+            .into_iter()
+            .try_fold(Uint128::zero(), |acc, (_, value)| acc.checked_add(value))
+            .map_err(Into::into)
+    }
 }
 
 #[cfg(test)]

--- a/packages/transmuter_math/src/rebalancing/mod.rs
+++ b/packages/transmuter_math/src/rebalancing/mod.rs
@@ -6,22 +6,25 @@ pub mod zone;
 use crate::TransmuterMathError as Error;
 use balance_shift::BalanceShift;
 use config::RebalancingConfig;
-use cosmwasm_std::{Decimal, Int256, SignedDecimal256, StdError, StdResult, Uint128};
+use cosmwasm_std::{Decimal, Int256, SignedDecimal256, StdError, StdResult};
 
 const DECIMAL_FRACTIONAL: Int256 = Int256::from_i128(1_000_000_000_000_000_000);
 
 /// Compute fee or incentive adjustment for a single asset's balance movement.
 ///
-/// This function calculates the incentive (if positive) or fee (if negative)
+/// This function calculates the incentive (if positive) or fee (if negative) rate
 /// for a swap that moves an asset's balance from balance to balance_new. The goal is to
 /// encourage movements toward the ideal balance range [ideal.start, ideal.end] and
 /// discourage movements away from it.
-pub fn compute_adjustment_value(
+///
+/// The total effective adjustment rate is the sum of the effective adjustment rates for each zone.
+/// The effective adjustment rate for a zone is the product of the zone's adjustment rate and the
+/// zone's weight. The weight is the normalized balance of the asset in the zone.
+pub fn compute_total_effective_adjustment_rate(
     balance: Decimal,
     balance_new: Decimal,
-    balance_total: Uint128,
     params: RebalancingConfig,
-) -> Result<Int256, Error> {
+) -> Result<SignedDecimal256, Error> {
     let balance_shift = BalanceShift::new(balance, balance_new)?;
     let ideal = params.ideal().clone();
 
@@ -38,18 +41,13 @@ pub fn compute_adjustment_value(
             })
         })?;
 
-    // Calculate the adjustment value
-    let adjustment_value = total_effective_adjustment_rate.checked_mul(
-        SignedDecimal256::from_atomics(Int256::from(balance_total), 0)?,
-    )?;
-
-    round_adjustment(adjustment_value)
+    Ok(total_effective_adjustment_rate)
 }
 
 /// Round a SignedDecimal256 to Int256 with appropriate rounding behavior:
 /// - For positive values: round down (give less incentive)
 /// - For negative values: round up (take more fee)
-fn round_adjustment(adjustment: SignedDecimal256) -> Result<Int256, Error> {
+pub fn round_adjustment(adjustment: SignedDecimal256) -> Result<Int256, Error> {
     if adjustment > SignedDecimal256::zero() {
         // For positive adjustments (incentives), round down to give less
         Ok(adjustment.atomics().checked_div(DECIMAL_FRACTIONAL)?)
@@ -73,7 +71,9 @@ fn round_adjustment(adjustment: SignedDecimal256) -> Result<Int256, Error> {
 mod tests {
     use super::*;
     use config::RebalancingConfig;
+    use cosmwasm_std::Decimal256;
     use rstest::rstest;
+    use std::str::FromStr;
 
     #[rstest]
     #[case(SignedDecimal256::percent(100), Int256::from(1))] // 1.0 -> 1
@@ -96,7 +96,6 @@ mod tests {
             (Decimal::percent(33), Decimal::percent(33)),
             (Decimal::percent(34), Decimal::percent(34)),
         ],
-        Uint128::new(1000)
     )]
     #[case::extreme_imbalance(
         vec![
@@ -104,7 +103,6 @@ mod tests {
             (Decimal::zero(), Decimal::zero()),
             (Decimal::percent(100), Decimal::percent(100)),
         ],
-        Uint128::new(1000)
     )]
     #[case::moving_to_balance(
         vec![
@@ -112,11 +110,9 @@ mod tests {
             (Decimal::percent(10), Decimal::percent(33)),
             (Decimal::percent(80), Decimal::percent(34)),
         ],
-        Uint128::new(1000)
     )]
     fn test_compute_adjustment_value_extreme_cases_properties(
         #[case] balances: Vec<(Decimal, Decimal)>,
-        #[case] balance_total: Uint128,
     ) {
         // Create extreme adjustment parameters with 100% rate
         let params = RebalancingConfig::new(
@@ -131,17 +127,17 @@ mod tests {
         .unwrap();
 
         // Calculate adjustments for each asset
-        let adjustments: Vec<Int256> = balances
+        let adjustments: Vec<SignedDecimal256> = balances
             .iter()
             .map(|(balance, balance_new)| {
-                compute_adjustment_value(*balance, *balance_new, balance_total, params.clone())
+                compute_total_effective_adjustment_rate(*balance, *balance_new, params.clone())
                     .unwrap()
             })
             .collect();
 
         // Verify adjustments are within bounds
         for adj in &adjustments {
-            assert!(adj.abs() <= Int256::from(balance_total));
+            assert!(adj.abs_diff(SignedDecimal256::zero()) <= Decimal256::one());
         }
 
         // Verify sum of balances is 100%
@@ -155,62 +151,52 @@ mod tests {
     #[case::no_movement(
         Decimal::percent(50),  // balance
         Decimal::percent(50),  // balance_new
-        Uint128::new(1000),   // balance_total
-        Int256::zero()        // expected_adjustment
+        SignedDecimal256::zero()        // expected_adjustment
     )]
     #[case::moving_into_ideal_range(
         Decimal::percent(10),  // balance
         Decimal::percent(33),  // balance_new
-        Uint128::new(1000),   // balance_total
-        Int256::from(11)      // expected_adjustment (positive, rounded down)
+        SignedDecimal256::from_str("0.011").unwrap()      // expected_adjustment (11/1000 = 0.011)
     )]
     #[case::moving_out_of_ideal_range(
         Decimal::percent(33),  // balance
         Decimal::percent(10),  // balance_new
-        Uint128::new(1000),   // balance_total
-        Int256::from(-11)     // expected_adjustment (negative, rounded up)
+        SignedDecimal256::from_str("-0.011").unwrap()     // expected_adjustment (-11/1000 = -0.011)
     )]
     #[case::small_movement_into_ideal(
         Decimal::percent(20),  // balance
         Decimal::percent(25),  // balance_new
-        Uint128::new(1000),   // balance_total
-        Int256::from(0)       // expected_adjustment (positive, rounded down)
+        SignedDecimal256::from_str("0.0005").unwrap()       // expected_adjustment (0.5/1000 = 0.0005)
     )]
     #[case::small_movement_out_of_ideal(
         Decimal::percent(25),  // balance
         Decimal::percent(20),  // balance_new
-        Uint128::new(1000),   // balance_total
-        Int256::from(-1)      // expected_adjustment (negative, rounded up)
+        SignedDecimal256::from_str("-0.0005").unwrap()      // expected_adjustment (-0.5/1000 = -0.0005)
     )]
     #[case::crossing_all_zones_into_ideal(
         Decimal::percent(5),   // balance (below critical lower)
         Decimal::percent(50),  // balance_new (into ideal range)
-        Uint128::new(1000),   // balance_total
-        Int256::from(16)     // expected_adjustment (positive, combines critical and strained rates)
+        SignedDecimal256::from_str("0.016").unwrap()     // expected_adjustment (16/1000 = 0.016)
     )]
     #[case::crossing_all_zones_out_of_ideal(
         Decimal::percent(50),  // balance (in ideal range)
         Decimal::percent(5),   // balance_new (below critical lower)
-        Uint128::new(1000),   // balance_total
-        Int256::from(-16)     // expected_adjustment (negative, combines critical and strained rates)
+        SignedDecimal256::from_str("-0.016").unwrap()     // expected_adjustment (-16/1000 = -0.016)
     )]
     #[case::crossing_critical_to_strained(
         Decimal::percent(5),   // balance (below critical lower)
         Decimal::percent(25),  // balance_new (into strained range)
-        Uint128::new(1000),   // balance_total
-        Int256::from(15)      // expected_adjustment (positive, critical rate)
+        SignedDecimal256::from_str("0.0155").unwrap()      // expected_adjustment (15.5/1000 = 0.0155)
     )]
     #[case::crossing_strained_to_critical(
         Decimal::percent(25),  // balance (in strained range)
         Decimal::percent(5),   // balance_new (below critical lower)
-        Uint128::new(1000),   // balance_total
-        Int256::from(-16)     // expected_adjustment (negative, critical rate)
+        SignedDecimal256::from_str("-0.0155").unwrap()     // expected_adjustment (-15.5/1000 = -0.0155)
     )]
     fn test_compute_adjustment_value(
         #[case] balance: Decimal,
         #[case] balance_new: Decimal,
-        #[case] balance_total: Uint128,
-        #[case] expected_adjustment: Int256,
+        #[case] expected_adjustment: SignedDecimal256,
     ) {
         let params = RebalancingConfig::new(
             Decimal::percent(70),  // ideal_upper
@@ -224,7 +210,7 @@ mod tests {
         .unwrap();
 
         let adjustment =
-            compute_adjustment_value(balance, balance_new, balance_total, params).unwrap();
+            compute_total_effective_adjustment_rate(balance, balance_new, params).unwrap();
 
         assert_eq!(adjustment, expected_adjustment);
     }

--- a/packages/transmuter_math/src/rebalancing/zone.rs
+++ b/packages/transmuter_math/src/rebalancing/zone.rs
@@ -19,8 +19,9 @@ pub struct Zone {
 
 impl Zone {
     pub fn new(start: Bound, end: Bound, adjustment_rate: Decimal) -> Self {
+        let (start_bound, end_bound) = force_inclusive_if_has_same_value(start, end);
         Self {
-            range: Range::new(inclusive_if_zero(start), inclusive_if_zero(end)).unwrap(),
+            range: Range::new(start_bound, end_bound).unwrap(),
             adjustment_rate,
         }
     }
@@ -56,11 +57,15 @@ impl Zone {
     }
 }
 
-fn inclusive_if_zero(bound: Bound) -> Bound {
-    if bound.value() == Decimal::zero() {
-        Bound::Inclusive(Decimal::zero())
+fn force_inclusive_if_has_same_value(start: Bound, end: Bound) -> (Bound, Bound) {
+    // If both bounds have the same value, make them both inclusive to create a valid single-point range
+    if start.value() == end.value() {
+        (
+            Bound::Inclusive(start.value()),
+            Bound::Inclusive(end.value()),
+        )
     } else {
-        bound
+        (start, end)
     }
 }
 


### PR DESCRIPTION
Depends on #45 

This does the same thing as #45 but for alloyed asset.

- swap alloyed to tokens
  - exact in: collect fees from out tokens
  - exact out: collect fees from alloyed in, which means fee portion will not be burned and burn the rest of the amount in
- swap tokens to alloyed
  - exact in: collect fees from out tokens (which is alloyed so it will mint fee to the contract and track it as part of incentive pool)
  - exact out: collect fees from tokens in